### PR TITLE
Added JANUS convolutional encoding

### DIFF
--- a/Application/Inc/MESS/mess_dsp_config.h
+++ b/Application/Inc/MESS/mess_dsp_config.h
@@ -44,6 +44,7 @@ typedef enum {
 typedef enum {
   NO_ECC,
   HAMMING_CODE,
+  JANUS_CONVOLUTIONAL,
   // Place others as needed here
   NUM_ECC_METHODS
 } ErrorCorrectionMethod_t;

--- a/Application/Inc/MESS/mess_main.h
+++ b/Application/Inc/MESS/mess_main.h
@@ -39,11 +39,10 @@ extern "C" {
 
 #define PACKET_DATA_MIN_LENGTH_BITS       (8 * 1)   // If the packet length is 0
 #define PACKET_DATA_MAX_LENGTH_BITS       (8 * 128) // If the packet length is 7
-#define PACKET_MAX_ERROR_DETECTION_BITS  32
-#define PACKET_MAX_LENGTH_BITS            (PACKET_SENDER_ID_BITS + \
-                                           PACKET_MESSAGE_TYPE_BITS + \
-                                           PACKET_LENGTH_BITS + \
-                                           PACKET_STATIONARY_BITS + \
+#define PACKET_MAX_ERROR_DETECTION_BITS   32
+// This is the number of bits in the *raw* message and is not to be used for
+// any ecc operation
+#define PACKET_MAX_LENGTH_BITS            (PACKET_PREAMBLE_LENGTH_BITS + \
                                            PACKET_DATA_MAX_LENGTH_BITS + \
                                            PACKET_MAX_ERROR_DETECTION_BITS)
 
@@ -55,9 +54,12 @@ extern "C" {
 // factor is based on the idea that convolutional codes will add the most 
 // number of errors to a message and they add bits as a multiplicative factor
 #define FACTOR_FOR_ECC                    2
+// At most 8 bits are added to flush the encoder in the janus convolutional encoder
+#define ADDED_ECC_BITS                    8
 
 // TODO: Add a check to see if the number of bytes is sufficient
-#define PACKET_MAX_LENGTH_BYTES           (((PACKET_MAX_LENGTH_BITS + 7) / 8) * \
+#define PACKET_MAX_LENGTH_BYTES           (((PACKET_MAX_LENGTH_BITS + \
+                                          ADDED_ECC_BITS * 2 + 7) / 8) * \
                                           FACTOR_FOR_ECC)
 // The data max length does not have ECC applied and is sanitized for a user
 #define PACKET_DATA_MAX_LENGTH_BYTES      (PACKET_DATA_MAX_LENGTH_BITS / 8)

--- a/Application/Inc/MESS/mess_main.h
+++ b/Application/Inc/MESS/mess_main.h
@@ -39,13 +39,13 @@ extern "C" {
 
 #define PACKET_DATA_MIN_LENGTH_BITS       (8 * 1)   // If the packet length is 0
 #define PACKET_DATA_MAX_LENGTH_BITS       (8 * 128) // If the packet length is 7
-#define PACKET_MAX_ERROR_CORRECTION_BITS  32
+#define PACKET_MAX_ERROR_DETECTION_BITS  32
 #define PACKET_MAX_LENGTH_BITS            (PACKET_SENDER_ID_BITS + \
                                            PACKET_MESSAGE_TYPE_BITS + \
                                            PACKET_LENGTH_BITS + \
                                            PACKET_STATIONARY_BITS + \
                                            PACKET_DATA_MAX_LENGTH_BITS + \
-                                           PACKET_MAX_ERROR_CORRECTION_BITS)
+                                           PACKET_MAX_ERROR_DETECTION_BITS)
 
 // Since there are multiple instances of BitMessage_t (The only time where the
 // packet max length in bytes is used), a static allocation was preferred over

--- a/Application/Inc/MESS/mess_packet.h
+++ b/Application/Inc/MESS/mess_packet.h
@@ -37,6 +37,7 @@ typedef struct {
   uint16_t non_preamble_length_ecc;
   uint16_t non_preamble_length;
   uint16_t combined_message_len; // not including ecc
+  float normalized_vitrebi_error_metric; // Only set when the ecc method uses convoltuional codes
   bool stationary_flag;
   bool preamble_received; // Set when first preamble number of bits received and decoded
   bool fully_received;    // Set when message bit count > final bit count

--- a/Application/Src/COMM/comm_config_menu.c
+++ b/Application/Src/COMM/comm_config_menu.c
@@ -1056,7 +1056,7 @@ void setErrorDetection(void* argument)
 void setPremableEcc(void* argument)
 {
   FunctionContext_t* context = (FunctionContext_t*) argument;
-  char* descriptors[] = {"None", "1-bit Hamming Code"};
+  char* descriptors[] = {"None", "1-bit Hamming Code", "1:2 Convolutional Code (JANUS)"};
 
   COMMLoops_LoopEnum(context, PARAM_ECC_PREAMBLE, descriptors,
     sizeof(descriptors) / sizeof(descriptors[0]));
@@ -1065,7 +1065,7 @@ void setPremableEcc(void* argument)
 void setMessageEcc(void* argument)
 {
   FunctionContext_t* context = (FunctionContext_t*) argument;
-  char* descriptors[] = {"None", "1-bit Hamming Code"};
+  char* descriptors[] = {"None", "1-bit Hamming Code", "1:2 Convolutional Code (JANUS)"};
 
   COMMLoops_LoopEnum(context, PARAM_ECC_MESSAGE, descriptors,
     sizeof(descriptors) / sizeof(descriptors[0]));

--- a/Application/Src/MESS/mess_error_correction.c
+++ b/Application/Src/MESS/mess_error_correction.c
@@ -16,31 +16,82 @@
 
 /* Private typedef -----------------------------------------------------------*/
 
+typedef struct {
+  uint16_t register_state;
+} ConvEncoder_t;
 
+typedef struct {
+  uint16_t section_length;
+  uint16_t start_raw_index;
+  uint16_t start_ecc_index;
+  uint16_t raw_len;
+  uint16_t ecc_len;
+} SectionInfo_t;
 
 /* Private define ------------------------------------------------------------*/
 
+/* 1:2 convolutional encoder defines -----------------------------------------*/
 
+// JANUS 1:2 convolutional encoder
+// g1(x) = x^8 + x^7 + x^5 + x^3 + x^2 + x^1 + 1
+// g2(x) = x^8 + x^4 + x^3 + x^2 + 1
+#define CE_G1_JANUS             0x01AF
+#define CE_G2_JANUS             0x011D
+
+#define JANUS_FLUSH_LENGTH      8
+#define JANUS_CONSTRAINT_LENGTH 9
+#define JANUS_NUM_STATES        (1 << (JANUS_CONSTRAINT_LENGTH - 1)) // 256 states
+#define JANUS_TRACEBACK_LENGTH  (JANUS_CONSTRAINT_LENGTH * 5)
+#define JANUS_MAX_METRIC        (100000.0f)
+#define JANUS_DECISION_LAG      (JANUS_CONSTRAINT_LENGTH * 3)
+
+#define JANUS_SOFT_DECISION     (false) // true to use soft decision and false otherwise
+
+typedef struct {
+  float path_metrics[JANUS_NUM_STATES];                         // Current path metrics
+  float next_path_metrics[JANUS_NUM_STATES];                    // Next iteration path metrics
+  uint16_t traceback[JANUS_TRACEBACK_LENGTH][JANUS_NUM_STATES]; // Survivor paths
+  uint16_t traceback_index;                                     // Current position in traceback array
+  float error_metric;                                           // Final error metric after decoding
+} JanusVitrebiDecoder_t;
 
 /* Private macro -------------------------------------------------------------*/
 
-
+#define MIN(x, y) ((x < y) ? (x) : (y))
 
 /* Private variables ---------------------------------------------------------*/
 
 static uint8_t message_buffer[PACKET_MAX_LENGTH_BYTES] = {0};
+static JanusVitrebiDecoder_t janus_decoder;
 
 /* Private function prototypes -----------------------------------------------*/
 
-static bool addHamming(BitMessage_t* bit_msg, bool is_preamble, uint16_t* bits_added);
-static bool decodeHamming(BitMessage_t* bit_msg, bool is_preamble, bool* error_detected, bool* error_corrected);
+static bool addHamming(BitMessage_t* bit_msg, bool is_preamble, uint16_t* bits_added, const DspConfig_t* cfg);
+static bool decodeHamming(BitMessage_t* bit_msg, bool is_preamble, bool* error_detected, bool* error_corrected, const DspConfig_t* cfg);
 
+static bool addJanusConvolutional(BitMessage_t* bit_msg, bool is_preamble, uint16_t* bits_added, const DspConfig_t* cfg);
+static bool decodeJanusConvolutional(BitMessage_t* bit_msg, bool is_preamble, bool* error_detected, bool* error_corrected, const DspConfig_t* cfg);
 
+// Hamming functions
 static uint16_t calculateNumParityBits(const uint16_t num_bits);
+
+// JANUS 1:2 convolutional encoder functions
+static void janusConvEncoderInit(ConvEncoder_t* encoder);
+static void janusConvEncodeBit(ConvEncoder_t* encoder, bool input_bit, bool output_bits[2]);
+static void janusVitrebiInit(JanusVitrebiDecoder_t* decoder);
+static float janusComputeBranchMetric(bool received_bit1, bool received_bit2,
+                                      bool expected_bit1, bool expected_bit2);
+static void janusCalculateOutput(uint16_t state, bool input_bit, bool output[2]);
+static void janusVitrebiDecodePair(JanusVitrebiDecoder_t* decoder, bool received_bit1, bool received_bit2);
+static bool janusVitrebiTraceback(JanusVitrebiDecoder_t* decoder, bool* bit, uint16_t bit_index);
+static uint16_t janusVitrebiFindBestState(JanusVitrebiDecoder_t* decoder);
+
+// General helper functions
 static void clearBuffer(void);
 static bool setBitInBuffer(bool bit, uint16_t position);
 static bool getBitFromBuffer(uint16_t position, bool* bit);
 static void copyBufferToMessage(BitMessage_t* bit_msg, uint16_t new_len);
+static void calculateSectionInfo(SectionInfo_t* section_info, const BitMessage_t* bit_msg, const DspConfig_t* cfg, bool is_preamble);
 
 /* Exported function definitions ---------------------------------------------*/
 
@@ -53,8 +104,12 @@ bool ErrorCorrection_AddCorrection(BitMessage_t* bit_msg,
     case NO_ECC:
       return true;
     case HAMMING_CODE:
-      // add hamming code
-      if (addHamming(bit_msg, true, &bits_added) == false) {
+      if (addHamming(bit_msg, true, &bits_added, cfg) == false) {
+        return false;
+      }
+      break;
+    case JANUS_CONVOLUTIONAL:
+      if (addJanusConvolutional(bit_msg, true, &bits_added, cfg) == false) {
         return false;
       }
       break;
@@ -66,7 +121,12 @@ bool ErrorCorrection_AddCorrection(BitMessage_t* bit_msg,
     case NO_ECC:
       return true;
     case HAMMING_CODE:
-      if (addHamming(bit_msg, false, &bits_added) == false) {
+      if (addHamming(bit_msg, false, &bits_added, cfg) == false) {
+        return false;
+      }
+      break;
+    case JANUS_CONVOLUTIONAL:
+      if (addJanusConvolutional(bit_msg, false, &bits_added, cfg) == false) {
         return false;
       }
       break;
@@ -87,6 +147,11 @@ bool ErrorCorrection_CheckCorrection(BitMessage_t* bit_msg,
   *error_corrected = false;
   bit_msg->combined_message_len = bit_msg->non_preamble_length +
         PACKET_PREAMBLE_LENGTH_BITS;
+  if (is_preamble == true) {
+    SectionInfo_t section_info;
+    calculateSectionInfo(&section_info, bit_msg, cfg, is_preamble);
+    bit_msg->final_length = section_info.ecc_len;
+  }
   if (is_preamble) {
     switch (cfg->ecc_method_preamble) {
       case NO_ECC:
@@ -94,7 +159,9 @@ bool ErrorCorrection_CheckCorrection(BitMessage_t* bit_msg,
         *error_corrected = false;
         return true;
       case HAMMING_CODE:
-        return decodeHamming(bit_msg, true, error_detected, error_corrected);
+        return decodeHamming(bit_msg, true, error_detected, error_corrected, cfg);
+      case JANUS_CONVOLUTIONAL:
+        return decodeJanusConvolutional(bit_msg, true, error_detected, error_corrected, cfg);
       default:
         return false;
     }
@@ -106,7 +173,9 @@ bool ErrorCorrection_CheckCorrection(BitMessage_t* bit_msg,
         *error_corrected = false;
         return true;
       case HAMMING_CODE:
-        return decodeHamming(bit_msg, false, error_detected, error_corrected);
+        return decodeHamming(bit_msg, false, error_detected, error_corrected, cfg);
+      case JANUS_CONVOLUTIONAL:
+        return decodeJanusConvolutional(bit_msg, false, error_detected, error_corrected, cfg); 
       default:
         return false;
     }
@@ -121,6 +190,8 @@ uint16_t ErrorCorrection_GetLength(const uint16_t length,
       return length;
     case HAMMING_CODE:
       return calculateNumParityBits(length) + length;
+    case JANUS_CONVOLUTIONAL:
+      return 2 * (length + JANUS_FLUSH_LENGTH);
     default:
       return 0;
   }
@@ -128,19 +199,17 @@ uint16_t ErrorCorrection_GetLength(const uint16_t length,
 
 /* Private function definitions ----------------------------------------------*/
 
-bool addHamming(BitMessage_t* bit_msg, bool is_preamble, uint16_t* bits_added)
+bool addHamming(BitMessage_t* bit_msg, 
+                bool is_preamble, 
+                uint16_t* bits_added, 
+                const DspConfig_t* cfg)
 {
-  uint16_t section_length = is_preamble ? PACKET_PREAMBLE_LENGTH_BITS :
-      (bit_msg->final_length - PACKET_PREAMBLE_LENGTH_BITS);
+  SectionInfo_t section_info;
+  calculateSectionInfo(&section_info, bit_msg, cfg, is_preamble);
+  
+  uint16_t parity_bits = calculateNumParityBits(section_info.section_length);
 
-  uint16_t start_raw_index = is_preamble ? 0 : PACKET_PREAMBLE_LENGTH_BITS;
-  uint16_t start_ecc_index = is_preamble ? 0 :
-      (calculateNumParityBits(PACKET_PREAMBLE_LENGTH_BITS) +
-      PACKET_PREAMBLE_LENGTH_BITS);
-
-  uint16_t parity_bits = calculateNumParityBits(section_length);
-
-  uint16_t final_length = section_length + parity_bits;
+  uint16_t final_length = section_info.section_length + parity_bits;
   uint16_t message_bits_added = 0;
   // Add message bits to mesage
   for (uint16_t i = 0; i < final_length; i++) {
@@ -148,16 +217,16 @@ bool addHamming(BitMessage_t* bit_msg, bool is_preamble, uint16_t* bits_added)
       continue;
     }
     bool bit_to_add;
-    if (Packet_GetBit(bit_msg, start_raw_index + message_bits_added++, 
+    if (Packet_GetBit(bit_msg, section_info.start_raw_index + message_bits_added++, 
                       &bit_to_add) == false) {
       return false;
     }
-    if (setBitInBuffer(bit_to_add, start_ecc_index + i) == false) {
+    if (setBitInBuffer(bit_to_add, section_info.start_ecc_index + i) == false) {
       return false;
     }
-    if (message_bits_added >= section_length) break;
+    if (message_bits_added >= section_info.section_length) break;
   }
-  if (message_bits_added != section_length) {
+  if (message_bits_added != section_info.section_length) {
     return false;
   }
 
@@ -169,14 +238,14 @@ bool addHamming(BitMessage_t* bit_msg, bool is_preamble, uint16_t* bits_added)
     for (uint16_t i = parity_pos; i < final_length; i++) {
       if ((i + 1) & (1 << p)) {
         bool bit;
-        if (getBitFromBuffer(i + start_ecc_index, &bit) == false) {
+        if (getBitFromBuffer(i + section_info.start_ecc_index, &bit) == false) {
           return false;
         }
         parity ^= bit;
       }
     }
 
-    if (setBitInBuffer(parity, parity_pos + start_ecc_index) == false) {
+    if (setBitInBuffer(parity, parity_pos + section_info.start_ecc_index) == false) {
       return false;
     }
   }
@@ -189,31 +258,22 @@ bool addHamming(BitMessage_t* bit_msg, bool is_preamble, uint16_t* bits_added)
 bool decodeHamming(BitMessage_t* bit_msg, 
                    bool is_preamble, 
                    bool* error_detected, 
-                   bool* error_corrected)
+                   bool* error_corrected,
+                   const DspConfig_t* cfg)
 {
-  uint16_t start_raw_index = is_preamble ? 0 : PACKET_PREAMBLE_LENGTH_BITS;
-  uint16_t start_ecc_index = is_preamble ? 0 :
-      (calculateNumParityBits(PACKET_PREAMBLE_LENGTH_BITS) +
-      PACKET_PREAMBLE_LENGTH_BITS);
-
-  uint16_t raw_len = is_preamble ? PACKET_PREAMBLE_LENGTH_BITS :
-      (bit_msg->non_preamble_length);
-  uint16_t ecc_len = calculateNumParityBits(raw_len) + raw_len;
-
-  if (is_preamble == true) {
-    bit_msg->final_length = ecc_len;
-  }
+  SectionInfo_t section_info;
+  calculateSectionInfo(&section_info, bit_msg, cfg, is_preamble);
 
   uint16_t syndrome = 0;
   uint16_t parity_bits = 0;
-  while ((1 << parity_bits) < ecc_len) {
+  while ((1 << parity_bits) < section_info.ecc_len) {
     uint16_t p = parity_bits;
     bool parity = false;
 
-    for (uint16_t i = 0; i < ecc_len; i++) {
+    for (uint16_t i = 0; i < section_info.ecc_len; i++) {
       if ((i + 1) & (1 << p)) {
         bool bit;
-        if (Packet_GetBit(bit_msg, i + start_ecc_index, &bit) == false) {
+        if (Packet_GetBit(bit_msg, i + section_info.start_ecc_index, &bit) == false) {
           return false;
         }
         parity ^= bit;
@@ -226,27 +286,129 @@ bool decodeHamming(BitMessage_t* bit_msg,
     parity_bits++;
   }
 
-  if (syndrome != 0) {
-    if (Packet_FlipBit(bit_msg, start_ecc_index + syndrome - 1) == false) {
+  if (syndrome != 0 && syndrome < section_info.ecc_len) {
+    if (Packet_FlipBit(bit_msg, section_info.start_ecc_index + syndrome - 1) == false) {
       return false;
     }
     *error_corrected = true;
   }
 
   uint16_t decoded_pos = 0;
-  for (uint16_t i = 0; i < ecc_len; i++) {
+  for (uint16_t i = 0; i < section_info.ecc_len; i++) {
     if (NumberUtils_IsPowerOf2(i + 1) == false) {
       bool bit;
-      if (Packet_GetBit(bit_msg, i + start_ecc_index, &bit) == false) {
+      if (Packet_GetBit(bit_msg, i + section_info.start_ecc_index, &bit) == false) {
         return false;
       }
-      if (Packet_SetBit(bit_msg, decoded_pos + start_raw_index, bit) == false) {
+      if (Packet_SetBit(bit_msg, decoded_pos + section_info.start_raw_index, bit) == false) {
         return false;
       }
       decoded_pos++;
-      if (decoded_pos >= raw_len) break;
+      if (decoded_pos >= section_info.raw_len) break;
     }
   }
+
+  return true;
+}
+
+bool addJanusConvolutional(BitMessage_t* bit_msg, 
+                           bool is_preamble, 
+                           uint16_t* bits_added, 
+                           const DspConfig_t* cfg)
+{
+  ConvEncoder_t encoder;
+  janusConvEncoderInit(&encoder);
+  SectionInfo_t section_info;
+  calculateSectionInfo(&section_info, bit_msg, cfg, is_preamble);
+
+  bool output_bits[2];
+  uint16_t output_index = section_info.start_ecc_index;
+
+  // First add the actual message bits
+  for (uint16_t i = 0; i < section_info.section_length; i++) {
+    bool input_bit;
+    if (Packet_GetBit(bit_msg, i + section_info.start_raw_index, &input_bit) == false) {
+      return false;
+    }
+
+    janusConvEncodeBit(&encoder, input_bit, output_bits);
+
+    if (setBitInBuffer(output_bits[0], output_index++) == false) {
+      return false;
+    }
+    if (setBitInBuffer(output_bits[1], output_index++) == false) {
+      return false;
+    }
+  }
+
+  // Then flush the encoder
+  for (uint16_t i = 0; i < JANUS_FLUSH_LENGTH; i++) {
+      janusConvEncodeBit(&encoder, false, output_bits);
+  
+      if (setBitInBuffer(output_bits[0], output_index++) == false) {
+        return false;
+      }
+      if (setBitInBuffer(output_bits[1], output_index++) == false) {
+        return false;
+      }
+    }
+  *bits_added += output_index;
+  return true;
+}
+
+bool decodeJanusConvolutional(BitMessage_t* bit_msg, 
+                              bool is_preamble, 
+                              bool* error_detected, 
+                              bool* error_corrected,
+                              const DspConfig_t* cfg)
+{
+  SectionInfo_t section_info;
+  calculateSectionInfo(&section_info, bit_msg, cfg, is_preamble);
+  janusVitrebiInit(&janus_decoder);
+
+  uint16_t output_bit_index = 0;
+
+  for (uint16_t i = 0; i < section_info.ecc_len; i += 2) {
+    uint16_t bit_position = section_info.start_ecc_index + i;
+    bool bit1, bit2;
+    if (Packet_GetBit(bit_msg, bit_position, &bit1) == false) {
+      return false;
+    }
+    if (Packet_GetBit(bit_msg, bit_position + 1, &bit2) == false) {
+      return false;
+    }
+
+    janusVitrebiDecodePair(&janus_decoder, bit1, bit2);
+
+    if (janus_decoder.traceback_index >= JANUS_TRACEBACK_LENGTH) {
+      bool bit;
+      if (janusVitrebiTraceback(&janus_decoder, &bit, output_bit_index) == false) {
+        return false;
+      }
+      if (Packet_SetBit(bit_msg, section_info.start_raw_index + output_bit_index, bit) == false) {
+        return false;
+      }
+      output_bit_index++;
+    }
+  } 
+
+  uint16_t remaining_bits = MIN(section_info.raw_len, JANUS_TRACEBACK_LENGTH);
+
+  for (uint16_t i = 0; i < remaining_bits; i++) {
+    bool bit;
+    if (janusVitrebiTraceback(&janus_decoder, &bit, output_bit_index) == false) {
+      return false;
+    }
+    if (Packet_SetBit(bit_msg, section_info.start_raw_index + output_bit_index, bit) == false) {
+      return false;
+    }
+    output_bit_index++;
+  }
+
+  bit_msg->normalized_vitrebi_error_metric = (float) janus_decoder.error_metric / (section_info.ecc_len / 2.0f);
+
+  *error_detected = bit_msg->normalized_vitrebi_error_metric != 0.0f;
+  *error_corrected = *error_detected;
 
   return true;
 }
@@ -259,6 +421,139 @@ uint16_t calculateNumParityBits(const uint16_t num_bits)
     parity_bits++;
   }
   return parity_bits;
+}
+
+void janusConvEncoderInit(ConvEncoder_t* encoder)
+{
+  encoder->register_state = 0;
+}
+
+void janusConvEncodeBit(ConvEncoder_t* encoder, bool input_bit, bool output_bits[2])
+{
+  encoder->register_state = ((encoder->register_state << 1) | (input_bit & 0x0001)) & 0x01FF;
+  uint16_t state = encoder->register_state;
+
+  output_bits[0] = __builtin_parity(state & CE_G1_JANUS);
+  output_bits[1] = __builtin_parity(state & CE_G2_JANUS);
+}
+
+void janusVitrebiInit(JanusVitrebiDecoder_t* decoder)
+{
+  memset(decoder, 0, sizeof(JanusVitrebiDecoder_t));
+
+  decoder->path_metrics[0] = 0.0f;
+  for (uint16_t i = 1; i < JANUS_NUM_STATES; i++) {
+    decoder->path_metrics[i] = JANUS_MAX_METRIC;
+  }
+
+  for (uint16_t i = 0; i < JANUS_NUM_STATES; i++) {
+    decoder->next_path_metrics[i] = JANUS_MAX_METRIC;
+  }
+
+  decoder->traceback_index = 0;
+  decoder->error_metric = 0.0f;
+}
+
+float janusComputeBranchMetric(bool received_bit1, bool received_bit2,
+                               bool expected_bit1, bool expected_bit2)
+{
+  // Soft decision vitrebi traceback uses a cotninuous range to decide how
+  // far off the branch is from actual. The continuous range is ususally a
+  // 4-byte float, but a 1- or 2-byte value could be used.
+  // Keeping the energies of each frequency for each bit would use 4 bytes
+  // of ram per bit which is acceptable with the current message lengths of
+  // ~ 2,000 but this could be a large hassle for longer message types. To
+  // alleviate this issue, a history of received bit energies could be kept
+  // that is say the most recent 10 decoded bit energies. The soft decision
+  // function could then call a function that would return the energy in the
+  // history array corresponding to the bit position. Considering how the
+  // MESS task is such a high priority task that is run often, this could
+  // be viable as the current maximum baud rate of 1000 gives 10 ms with
+  // an energy history of 10. TODO (investigate soft decision vitrebi)
+  #if JANUS_SOFT_DECISION
+    return (received_bit1 - expected_bit1) * (received_bit1 - expected_bit1) + 
+           (received_bit2 - expected_bit2) * (received_bit2 - expected_bit2);
+  #else /* JANUS_SOFT_DECISION */
+    return (float) (received_bit1 != expected_bit1) + (received_bit2 != expected_bit2);
+  #endif /* JANUS_SOFT_DECISION*/
+}
+
+void janusCalculateOutput(uint16_t state, bool input_bit, bool output[2])
+{
+  uint16_t full_state = ((state << 1) | input_bit) & 0x01FF;
+
+  output[0] = __builtin_parity(full_state & CE_G1_JANUS);
+  output[1] = __builtin_parity(full_state & CE_G2_JANUS);
+}
+
+void janusVitrebiDecodePair(JanusVitrebiDecoder_t* decoder, bool received_bit1, bool received_bit2)
+{
+  for (uint16_t i = 0; i < JANUS_NUM_STATES; i++) {
+    decoder->next_path_metrics[i] = JANUS_MAX_METRIC;
+  }
+
+  uint16_t tb_index = decoder->traceback_index % JANUS_TRACEBACK_LENGTH;
+
+  for (uint16_t current_state = 0; current_state < JANUS_NUM_STATES; current_state++) {
+    // States with infinite metrics are ignored
+    if (decoder->path_metrics[current_state] >= JANUS_MAX_METRIC) continue;
+
+    // Calculate branch metrics as if actual bit was either 0 or 1
+    for (uint8_t input_bit = 0; input_bit <= 1; input_bit++) {
+      bool expected_output[2];
+      janusCalculateOutput(current_state, input_bit, expected_output);
+
+      float branch_metric = janusComputeBranchMetric(
+        received_bit1,      received_bit2,
+        expected_output[0], expected_output[1]
+      );
+
+      uint16_t next_state = ((current_state << 1) | input_bit) & 0x00FF;
+
+      float new_path_metric = decoder->path_metrics[current_state] + branch_metric;
+
+      if (new_path_metric < decoder->next_path_metrics[next_state]) {
+        decoder->next_path_metrics[next_state] = new_path_metric;
+        decoder->traceback[tb_index][next_state] = current_state;
+      }
+    }
+  }
+
+  decoder->traceback_index++;
+  memcpy(decoder->path_metrics, decoder->next_path_metrics, sizeof(decoder->path_metrics));
+}
+
+// TODO: optimize for repeated tracebacks with the same path
+bool janusVitrebiTraceback(JanusVitrebiDecoder_t* decoder, bool* bit, uint16_t bit_index)
+{
+  if (bit_index >= decoder->traceback_index) {
+    return false;
+  }
+  uint16_t current_state = janusVitrebiFindBestState(decoder);
+
+  uint16_t available_symbols = decoder->traceback_index - bit_index - 1;
+
+  for (uint16_t i = 0; i < available_symbols; i++) {
+    uint16_t tb_index = (decoder->traceback_index - 1 - i) % JANUS_TRACEBACK_LENGTH;
+    current_state = decoder->traceback[tb_index][current_state];
+  }
+
+  *bit = current_state & 0x0001;
+  return true;
+}
+
+static uint16_t janusVitrebiFindBestState(JanusVitrebiDecoder_t* decoder)
+{
+  uint16_t best_state = 0;
+  float min_metric = decoder->path_metrics[0];
+
+  for (uint16_t i = 1; i < JANUS_NUM_STATES; i++) {
+    if (decoder->path_metrics[i] < min_metric) {
+      min_metric = decoder->path_metrics[i];
+      best_state = i;
+    }
+  }
+  return best_state;
 }
 
 void clearBuffer(void)
@@ -302,4 +597,17 @@ void copyBufferToMessage(BitMessage_t* bit_msg, uint16_t new_len)
   memcpy(bit_msg->data, message_buffer, sizeof(message_buffer) / sizeof(message_buffer[0]));
   bit_msg->bit_count = new_len;
   bit_msg->final_length = new_len;
+}
+
+static void calculateSectionInfo(SectionInfo_t* section_info, const BitMessage_t* bit_msg, const DspConfig_t* cfg, bool is_preamble)
+{
+  section_info->section_length = is_preamble ? PACKET_PREAMBLE_LENGTH_BITS :
+      (bit_msg->final_length - PACKET_PREAMBLE_LENGTH_BITS);
+  section_info->start_raw_index = is_preamble ? 0 : PACKET_PREAMBLE_LENGTH_BITS;
+  section_info->start_ecc_index = is_preamble ? 0 : 
+      ErrorCorrection_GetLength(section_info->start_raw_index, cfg->ecc_method_preamble);
+  section_info->raw_len = is_preamble ? PACKET_PREAMBLE_LENGTH_BITS :
+      (bit_msg->non_preamble_length);
+  section_info->ecc_len = ErrorCorrection_GetLength(section_info->raw_len,
+      is_preamble ? cfg->ecc_method_preamble : cfg->ecc_method_message);
 }

--- a/Application/Src/MESS/mess_error_correction.c
+++ b/Application/Src/MESS/mess_error_correction.c
@@ -46,7 +46,6 @@ typedef struct {
 #define JANUS_NUM_STATES        (1 << (JANUS_CONSTRAINT_LENGTH - 1)) // 256 states
 #define JANUS_TRACEBACK_LENGTH  (JANUS_CONSTRAINT_LENGTH * 5)
 #define JANUS_MAX_METRIC        (100000.0f)
-#define JANUS_DECISION_LAG      (JANUS_CONSTRAINT_LENGTH * 3)
 
 #define JANUS_SOFT_DECISION     (false) // true to use soft decision and false otherwise
 

--- a/Application/Src/MESS/mess_error_detection.c
+++ b/Application/Src/MESS/mess_error_detection.c
@@ -19,7 +19,12 @@
 
 /* Private define ------------------------------------------------------------*/
 
-
+// x^2 + x^1 + 1
+#define CRC_8_POLYNOMIAL  0x07U 
+// x^12 + x^5 + 1
+#define CRC_16_POLYNOMIAL 0x1021U
+// x^26 + x^23 + x^22 + x^16 + x^12 + x^11 + x^10 + x^8 + x^7 + x^5 + x^4 + x^2 + x^1 + 1
+#define CRC_32_POLYNOMIAL 0x04C11DB7U 
 
 /* Private macro -------------------------------------------------------------*/
 
@@ -163,7 +168,7 @@ bool calculateCrc8(BitMessage_t* bit_msg, uint8_t* crc)
     return false;
   }
 
-  uint8_t polynomial = 0x07;
+  uint8_t polynomial = CRC_8_POLYNOMIAL;
   *crc = 0;
 
   uint16_t byte_count = (bit_msg->combined_message_len - 8) / 8;
@@ -204,7 +209,7 @@ bool calculateCrc16(BitMessage_t* bit_msg, uint16_t* crc)
     return false;
   }
 
-  uint16_t polynomial = 0x1021;
+  uint16_t polynomial = CRC_16_POLYNOMIAL;
   *crc = 0xFFFF;
 
   uint16_t byte_count = (bit_msg->combined_message_len - 16) / 8;
@@ -245,7 +250,7 @@ bool calculateCrc32(BitMessage_t* bit_msg, uint32_t* crc)
     return false;
   }
 
-  uint32_t polynomial = 0x04C11DB7;
+  uint32_t polynomial = CRC_32_POLYNOMIAL;
   *crc = 0xFFFFFFFF;
 
   uint16_t byte_count = (bit_msg->combined_message_len - 32) / 8;

--- a/Application/Src/MESS/mess_feedback_tests.c
+++ b/Application/Src/MESS/mess_feedback_tests.c
@@ -226,6 +226,25 @@ static FeedbackTests_t feedback_tests[] = {
         .reference_message = &reference_messages[4],
         .errors_added = 1,
         .repetitions = 20
+    },
+    {
+      .cfg = {
+          .baud_rate = 1000.0f,
+          .mod_demod_method = MOD_DEMOD_FSK,
+          .fsk_f0 = 29000,
+          .fsk_f1 = 33000,
+          .fc = 31000,
+          .fhbfsk_freq_spacing = 1,
+          .fhbfsk_num_tones = 10,
+          .fhbfsk_dwell_time = 1,
+          .error_detection_method = CRC_16,
+          .ecc_method_preamble = JANUS_CONVOLUTIONAL,
+          .ecc_method_message = JANUS_CONVOLUTIONAL
+      },
+      .expected_result = IDENTICAL,
+      .reference_message = &reference_messages[4],
+      .errors_added = 2,
+      .repetitions = 20
     }
 };
 
@@ -437,12 +456,11 @@ bool getTestIndex(uint16_t* index)
   uint16_t counter = 0;
   for (uint16_t i = 0; i < unique_tests; i++)
   {
-    if (current_test <= counter) {
+    counter += feedback_tests[i].repetitions;
+    if (current_test <= (counter - 1)) {
       *index = i;
       return true;
     }
-
-    counter += feedback_tests[i].repetitions;
   }
   if (current_test >= total_tests) {
     return false;

--- a/Application/Src/MESS/mess_packet.c
+++ b/Application/Src/MESS/mess_packet.c
@@ -177,11 +177,11 @@ bool Packet_FlipBit(BitMessage_t* bit_msg, uint16_t bit_index)
 
 bool Packet_SetBit(BitMessage_t* bit_msg, uint16_t bit_index, bool bit)
 {
-  if (bit_msg->bit_count >= PACKET_MAX_LENGTH_BITS) {
+  if (bit_msg->bit_count >= PACKET_MAX_LENGTH_BYTES * 8) {
     return false;
   }
 
-  uint8_t byte_index = bit_index / 8;
+  uint16_t byte_index = bit_index / 8;
   uint8_t bit_position = bit_index % 8;
 
   if (bit == true) {


### PR DESCRIPTION
Added JANUS 1:2 convolutional encoding ANEP-87 version 2. ANEP-87 does not specify a method for decoding so some liberty was taken here according to common practices. I implemented a sliding window decoder with a traceback length of 45 (K*9) as this is relatively standard. The primary issue with it is that it uses a fair amount of RAM (~25 kB) but it does not appear to be overly computationally demanding. If the computational strain becomes too much, the traceback sequence could be modified with a cache.

It is unlikely that a convolutional code with a higher constraint length could be used as increasing the constraint length by 1 ~doubles RAM usage.