### PR TITLE
Add JANUS interleaver

### DIFF
--- a/Application/Inc/CFG/cfg_defaults.h
+++ b/Application/Inc/CFG/cfg_defaults.h
@@ -175,6 +175,10 @@ extern "C" {
 #define MIN_ECC_METHOD              0
 #define MAX_ECC_METHOD              (NUM_ECC_METHODS - 1)
 
+#define DEFAULT_INTERLEAVER_STATE   (false)
+#define MIN_INTERLEAVER_STATE       (false)
+#define MAX_INTERLEAVER_STATE       (true)
+
 /* Exported macro ------------------------------------------------------------*/
 
 

--- a/Application/Inc/CFG/cfg_parameters.h
+++ b/Application/Inc/CFG/cfg_parameters.h
@@ -66,6 +66,7 @@ typedef enum {
   PARAM_FIXED_PGA_GAIN,
   PARAM_ECC_PREAMBLE,
   PARAM_ECC_MESSAGE,
+  PARAM_USE_INTERLEAVER,
   // Add new parameters here and nowhere else
   NUM_PARAM
 } ParamIds_t;

--- a/Application/Inc/COMM/comm_menu_system.h
+++ b/Application/Inc/COMM/comm_menu_system.h
@@ -47,6 +47,7 @@ typedef enum {
   MENU_ID_CFG_UNIV_FC,          // Center frequency used 
   MENU_ID_CFG_UNIV_BP,          // Bit period used in the baud rate. Currently the inverse of ^^
   MENU_ID_CFG_UNIV_BANDWIDTH,   // Bandwidth
+  MENU_ID_CFG_UNIV_INTERLEAVER, // Whether to use the JANUS interleaver
   MENU_ID_CFG_UNIV_EXP,         // Export the configuration options used
   MENU_ID_CFG_UNIV_IMP,         // Import configuration options
   MENU_ID_CFG_MOD,              // Waveform modulation parameters

--- a/Application/Inc/MESS/mess_dsp_config.h
+++ b/Application/Inc/MESS/mess_dsp_config.h
@@ -51,6 +51,7 @@ typedef enum {
 
 // Struct for all configuration parameters that are relevant for feedback tests
 // Other configuration parameters belong to modules
+// IMPORTANT: Any modification to parameters here must be reflected in the feedback tests
 typedef struct {
   float baud_rate;
   ModDemodMethod_t mod_demod_method;

--- a/Application/Inc/MESS/mess_dsp_config.h
+++ b/Application/Inc/MESS/mess_dsp_config.h
@@ -14,7 +14,7 @@ extern "C" {
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32h7xx_hal.h"
-
+#include <stdbool.h>
 
 /* Private includes ----------------------------------------------------------*/
 
@@ -63,6 +63,7 @@ typedef struct {
   ErrorDetectionMethod_t error_detection_method;
   ErrorCorrectionMethod_t ecc_method_preamble;
   ErrorCorrectionMethod_t ecc_method_message;
+  bool use_interleaver;
 } DspConfig_t;
 
 

--- a/Application/Inc/MESS/mess_interleaver.h
+++ b/Application/Inc/MESS/mess_interleaver.h
@@ -1,0 +1,47 @@
+/*
+ * mess_interleaver.h
+ *
+ *  Created on: Jun 1, 2025
+ *      Author: ericv
+ */
+
+#ifndef MESS_MESS_INTERLEAVER_H_
+#define MESS_MESS_INTERLEAVER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32h7xx_hal.h"
+#include "mess_packet.h"
+#include <stdbool.h>
+
+/* Private includes ----------------------------------------------------------*/
+
+
+
+/* Exported types ------------------------------------------------------------*/
+
+
+
+/* Exported constants --------------------------------------------------------*/
+
+
+
+/* Exported macro ------------------------------------------------------------*/
+
+
+
+/* Exported functions prototypes ---------------------------------------------*/
+
+bool Interleaver_Apply(BitMessage_t* bit_msg, const DspConfig_t* cfg);
+bool Interleaver_Undo(BitMessage_t* bit_msg, const DspConfig_t* cfg, bool is_preamble);
+
+/* Private defines -----------------------------------------------------------*/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MESS_MESS_INTERLEAVER_H_ */

--- a/Application/Inc/MESS/mess_interleaver.h
+++ b/Application/Inc/MESS/mess_interleaver.h
@@ -35,7 +35,27 @@ extern "C" {
 
 /* Exported functions prototypes ---------------------------------------------*/
 
+/**
+ * @brief Interleaves a message following the JANUS standard
+ * 
+ * @param bit_msg Message to be interleaved (modified)
+ * @param cfg Configuration values (decides whether interleaving should occur)
+ * @return true if successful false otherwise
+ * 
+ * @see Interleaver_Undo()
+ */
 bool Interleaver_Apply(BitMessage_t* bit_msg, const DspConfig_t* cfg);
+
+/**
+ * @brief Deinterleaves a message following the JANUS standard
+ * 
+ * @param bit_msg Message with interleaving applied (modified)
+ * @param cfg Configuration values (decides whether interleaving should occur)
+ * @param is_preamble Which part of the message to deinterleave
+ * @return true if successful, false otherwise
+ * 
+ * @see Interleaver_Apply()
+ */
 bool Interleaver_Undo(BitMessage_t* bit_msg, const DspConfig_t* cfg, bool is_preamble);
 
 /* Private defines -----------------------------------------------------------*/

--- a/Application/Src/CFG/cfg_import_export.c
+++ b/Application/Src/CFG/cfg_import_export.c
@@ -36,6 +36,8 @@
 
 /* Private variables ---------------------------------------------------------*/
 
+// List of all parameters that are exported. New parameters can be added
+// anywhere in the list and parameters do not need to be in order
 static ParamIds_t imp_exp_parameters[] = {
     PARAM_BAUD,
     PARAM_FSK_F0,
@@ -47,7 +49,8 @@ static ParamIds_t imp_exp_parameters[] = {
     PARAM_FHBFSK_NUM_TONES,
     PARAM_ERROR_DETECTION,
     PARAM_ECC_PREAMBLE,
-    PARAM_ECC_MESSAGE
+    PARAM_ECC_MESSAGE,
+    PARAM_USE_INTERLEAVER
 };
 
 static const uint16_t num_param = sizeof(imp_exp_parameters) / sizeof(imp_exp_parameters[0]);

--- a/Application/Src/COMM/comm_config_menu.c
+++ b/Application/Src/COMM/comm_config_menu.c
@@ -48,6 +48,7 @@ void setBaudRate(void* argument);
 void setCenterFrequency(void* argument);
 void getBitPeriod(void* argument);
 void getBandwidth(void* argument);
+void toggleInterleaver(void* argument);
 void printConfigOptions(void* argument);
 void importConfiOptions(void* argument);
 void setDacTransitionDuration(void* argument);
@@ -111,7 +112,8 @@ static MenuID_t univConfigMenuChildren[] = {
   MENU_ID_CFG_UNIV_FSK,         MENU_ID_CFG_UNIV_FHBFSK,  
   MENU_ID_CFG_UNIV_BAUD,        MENU_ID_CFG_UNIV_FC,    
   MENU_ID_CFG_UNIV_BP,          MENU_ID_CFG_UNIV_BANDWIDTH, 
-  MENU_ID_CFG_UNIV_EXP,         MENU_ID_CFG_UNIV_IMP
+  MENU_ID_CFG_UNIV_INTERLEAVER, MENU_ID_CFG_UNIV_EXP, 
+  MENU_ID_CFG_UNIV_IMP
 };
 static const MenuNode_t univConfigMenu = {
   .id = MENU_ID_CFG_UNIV,
@@ -363,6 +365,21 @@ static const MenuNode_t univConfigBandwidth = {
   .num_children = 0,
   .access_level = 0,
   .parameters = &univConfigBandwidthParam
+};
+
+static ParamContext_t univConfigInterleaverParam = {
+  .state = PARAM_STATE_0,
+  .param_id = MENU_ID_CFG_UNIV_INTERLEAVER
+};
+static const MenuNode_t univConfigInterleaver = {
+  .id = MENU_ID_CFG_UNIV_INTERLEAVER,
+  .description = "Toggle Interleaver",
+  .handler = toggleInterleaver,
+  .parent_id = MENU_ID_CFG_UNIV,
+  .children_ids = NULL,
+  .num_children = 0,
+  .access_level = 0,
+  .parameters = &univConfigInterleaverParam
 };
 
 static ParamContext_t univConfigExportParam = {
@@ -1014,7 +1031,7 @@ bool COMM_RegisterConfigurationMenu()
              registerMenu(&univConfigExport) && registerMenu(&univConfigImport) && 
              registerMenu(&setStationary) && registerMenu(&modConfigDacTransition) &&
              registerMenu(&modConfigCalMenu) && registerMenu(&modConfigFeedbackMenu) && 
-             registerMenu(&modConfigMethod) && 
+             registerMenu(&modConfigMethod) && registerMenu(&univConfigInterleaver) &&
              registerMenu(&demodConfigCalMenu) && 
              registerMenu(&dauConfigSleep) && registerMenu(&ledConfigBrightness) &&
              registerMenu(&ledConfigToggle) && registerMenu(&modCalConfigLowFreq) &&
@@ -1254,6 +1271,13 @@ void getBandwidth(void* argument)
   COMM_TransmitData(context->output_buffer, CALC_LEN, context->comm_interface);
 
   context->state->state = PARAM_STATE_COMPLETE;
+}
+
+void toggleInterleaver(void* argument)
+{
+  FunctionContext_t* context = (FunctionContext_t*) argument;
+
+  COMMLoops_LoopToggle(context, PARAM_USE_INTERLEAVER);
 }
 
 void printConfigOptions(void* argument)

--- a/Application/Src/MESS/mess_error_detection.c
+++ b/Application/Src/MESS/mess_error_detection.c
@@ -59,6 +59,7 @@ bool ErrorDetection_AddDetection(BitMessage_t* bit_msg, const DspConfig_t* cfg)
       uint8_t crc_8;
       bit_msg->final_length += 8;
       bit_msg->combined_message_len += 8;
+      bit_msg->cargo.raw_len += 8;
       if (calculateCrc8(bit_msg, &crc_8) == false) {
         return false;
       }
@@ -67,6 +68,7 @@ bool ErrorDetection_AddDetection(BitMessage_t* bit_msg, const DspConfig_t* cfg)
       uint16_t crc_16;
       bit_msg->final_length += 16;
       bit_msg->combined_message_len += 16;
+      bit_msg->cargo.raw_len += 16;
       if (calculateCrc16(bit_msg, &crc_16) == false) {
         return false;
       }
@@ -75,6 +77,7 @@ bool ErrorDetection_AddDetection(BitMessage_t* bit_msg, const DspConfig_t* cfg)
       uint32_t crc_32;
       bit_msg->final_length += 32;
       bit_msg->combined_message_len += 32;
+      bit_msg->cargo.raw_len += 32;
       if (calculateCrc32(bit_msg, &crc_32) == false) {
         return false;
       }
@@ -83,6 +86,7 @@ bool ErrorDetection_AddDetection(BitMessage_t* bit_msg, const DspConfig_t* cfg)
       uint8_t checksum_8;
       bit_msg->final_length += 8;
       bit_msg->combined_message_len += 8;
+      bit_msg->cargo.raw_len += 8;
       if (calculateChecksum8(bit_msg, &checksum_8) == false) {
         return false;
       }
@@ -91,6 +95,7 @@ bool ErrorDetection_AddDetection(BitMessage_t* bit_msg, const DspConfig_t* cfg)
       uint16_t checksum_16;
       bit_msg->final_length += 16;
       bit_msg->combined_message_len += 16;
+      bit_msg->cargo.raw_len += 16;
       if (calculateChecksum16(bit_msg, &checksum_16) == false) {
         return false;
       }
@@ -99,6 +104,7 @@ bool ErrorDetection_AddDetection(BitMessage_t* bit_msg, const DspConfig_t* cfg)
       uint32_t checksum_32;
       bit_msg->final_length += 32;
       bit_msg->combined_message_len += 32;
+      bit_msg->cargo.raw_len += 32;
       if (calculateChecksum32(bit_msg, &checksum_32) == false) {
         return false;
       }

--- a/Application/Src/MESS/mess_error_detection.c
+++ b/Application/Src/MESS/mess_error_detection.c
@@ -19,11 +19,11 @@
 
 /* Private define ------------------------------------------------------------*/
 
-// x^2 + x^1 + 1
+// x^8 + x^2 + x^1 + 1
 #define CRC_8_POLYNOMIAL  0x07U 
-// x^12 + x^5 + 1
-#define CRC_16_POLYNOMIAL 0x1021U
-// x^26 + x^23 + x^22 + x^16 + x^12 + x^11 + x^10 + x^8 + x^7 + x^5 + x^4 + x^2 + x^1 + 1
+// x^16 + x^15 + x^2 + 1
+#define CRC_16_POLYNOMIAL 0x8005U
+// x^32 + x^26 + x^23 + x^22 + x^16 + x^12 + x^11 + x^10 + x^8 + x^7 + x^5 + x^4 + x^2 + x^1 + 1
 #define CRC_32_POLYNOMIAL 0x04C11DB7U 
 
 /* Private macro -------------------------------------------------------------*/
@@ -54,57 +54,46 @@ bool checkChecksum32(BitMessage_t* bit_msg, bool* error);
 
 bool ErrorDetection_AddDetection(BitMessage_t* bit_msg, const DspConfig_t* cfg)
 {
+  uint16_t len;
+  if (ErrorDetection_CheckLength(&len, cfg) == false) {
+    return false;
+  }
+  bit_msg->final_length += len;
+  bit_msg->combined_message_len += len;
+  bit_msg->cargo.raw_len += len;
   switch (cfg->error_detection_method) {
     case CRC_8:
       uint8_t crc_8;
-      bit_msg->final_length += 8;
-      bit_msg->combined_message_len += 8;
-      bit_msg->cargo.raw_len += 8;
       if (calculateCrc8(bit_msg, &crc_8) == false) {
         return false;
       }
       return Packet_Add8(bit_msg, crc_8);
     case CRC_16:
       uint16_t crc_16;
-      bit_msg->final_length += 16;
-      bit_msg->combined_message_len += 16;
-      bit_msg->cargo.raw_len += 16;
       if (calculateCrc16(bit_msg, &crc_16) == false) {
         return false;
       }
       return Packet_Add16(bit_msg, crc_16);
     case CRC_32:
       uint32_t crc_32;
-      bit_msg->final_length += 32;
-      bit_msg->combined_message_len += 32;
-      bit_msg->cargo.raw_len += 32;
       if (calculateCrc32(bit_msg, &crc_32) == false) {
         return false;
       }
       return Packet_Add32(bit_msg, crc_32);
     case CHECKSUM_8:
       uint8_t checksum_8;
-      bit_msg->final_length += 8;
-      bit_msg->combined_message_len += 8;
-      bit_msg->cargo.raw_len += 8;
       if (calculateChecksum8(bit_msg, &checksum_8) == false) {
         return false;
       }
       return Packet_Add8(bit_msg, checksum_8);
     case CHECKSUM_16:
       uint16_t checksum_16;
-      bit_msg->final_length += 16;
-      bit_msg->combined_message_len += 16;
-      bit_msg->cargo.raw_len += 16;
       if (calculateChecksum16(bit_msg, &checksum_16) == false) {
         return false;
       }
       return Packet_Add16(bit_msg, checksum_16);
     case CHECKSUM_32:
       uint32_t checksum_32;
-      bit_msg->final_length += 32;
-      bit_msg->combined_message_len += 32;
-      bit_msg->cargo.raw_len += 32;
       if (calculateChecksum32(bit_msg, &checksum_32) == false) {
         return false;
       }

--- a/Application/Src/MESS/mess_feedback_tests.c
+++ b/Application/Src/MESS/mess_feedback_tests.c
@@ -170,6 +170,7 @@ static ReferenceMessage_t reference_messages[] = {
 };
 
 static FeedbackTests_t feedback_tests[] = {
+  // Base FH-BFSK test
     {
         .cfg = {
             .baud_rate = 100.0f,
@@ -182,13 +183,15 @@ static FeedbackTests_t feedback_tests[] = {
             .fhbfsk_dwell_time = 1,
             .error_detection_method = CRC_16,
             .ecc_method_preamble = NO_ECC,
-            .ecc_method_message = NO_ECC
+            .ecc_method_message = NO_ECC,
+            .use_interleaver = false
         },
         .expected_result = IDENTICAL,
         .reference_message = &reference_messages[2],
         .errors_added = 0,
         .repetitions = 1
     },
+    // Base FSK test
     {
         .cfg = {
             .baud_rate = 100.0f,
@@ -201,13 +204,15 @@ static FeedbackTests_t feedback_tests[] = {
             .fhbfsk_dwell_time = 1,
             .error_detection_method = CRC_16,
             .ecc_method_preamble = NO_ECC,
-            .ecc_method_message = NO_ECC
+            .ecc_method_message = NO_ECC,
+            .use_interleaver = false
         },
         .expected_result = IDENTICAL,
         .reference_message = &reference_messages[2],
         .errors_added = 0,
         .repetitions = 1
     },
+    // Base Hamming code test
     {
         .cfg = {
             .baud_rate = 1000.0f,
@@ -220,13 +225,15 @@ static FeedbackTests_t feedback_tests[] = {
             .fhbfsk_dwell_time = 1,
             .error_detection_method = CRC_16,
             .ecc_method_preamble = HAMMING_CODE,
-            .ecc_method_message = HAMMING_CODE
+            .ecc_method_message = HAMMING_CODE,
+            .use_interleaver = false
         },
         .expected_result = IDENTICAL,
         .reference_message = &reference_messages[4],
         .errors_added = 1,
         .repetitions = 20
     },
+    // Base convolutional code test
     {
       .cfg = {
           .baud_rate = 1000.0f,
@@ -239,12 +246,55 @@ static FeedbackTests_t feedback_tests[] = {
           .fhbfsk_dwell_time = 1,
           .error_detection_method = CRC_16,
           .ecc_method_preamble = JANUS_CONVOLUTIONAL,
-          .ecc_method_message = JANUS_CONVOLUTIONAL
+          .ecc_method_message = JANUS_CONVOLUTIONAL,
+          .use_interleaver = false
       },
       .expected_result = IDENTICAL,
       .reference_message = &reference_messages[4],
       .errors_added = 2,
       .repetitions = 20
+    },
+    // Base interleaver test
+    {
+      .cfg = {
+          .baud_rate = 1000.0f,
+          .mod_demod_method = MOD_DEMOD_FSK,
+          .fsk_f0 = 29000,
+          .fsk_f1 = 33000,
+          .fc = 31000,
+          .fhbfsk_freq_spacing = 1,
+          .fhbfsk_num_tones = 10,
+          .fhbfsk_dwell_time = 1,
+          .error_detection_method = CRC_16,
+          .ecc_method_preamble = NO_ECC,
+          .ecc_method_message = NO_ECC,
+          .use_interleaver = true
+      },
+      .expected_result = IDENTICAL,
+      .reference_message = &reference_messages[4],
+      .errors_added = 0,
+      .repetitions = 1
+    },
+    // Advanced interleaver/convolutional test (long)
+    {
+      .cfg = {
+          .baud_rate = 1000.0f,
+          .mod_demod_method = MOD_DEMOD_FSK,
+          .fsk_f0 = 29000,
+          .fsk_f1 = 33000,
+          .fc = 31000,
+          .fhbfsk_freq_spacing = 1,
+          .fhbfsk_num_tones = 10,
+          .fhbfsk_dwell_time = 1,
+          .error_detection_method = CRC_16,
+          .ecc_method_preamble = JANUS_CONVOLUTIONAL,
+          .ecc_method_message = JANUS_CONVOLUTIONAL,
+          .use_interleaver = true
+      },
+      .expected_result = IDENTICAL,
+      .reference_message = &reference_messages[7],
+      .errors_added = 5,
+      .repetitions = 1
     }
 };
 
@@ -560,6 +610,9 @@ static void printStatistics(void)
         "Error detection method: %u\r\nError correction method: %u %u\r\n", 
         cfg->baud_rate, cfg->mod_demod_method, cfg->error_detection_method,
         cfg->ecc_method_preamble, cfg->ecc_method_message);
+    COMM_TransmitData(output_buffer, CALC_LEN, COMM_USB);
+
+    snprintf(output_buffer, 128, "interleaver: %u\r\n", cfg->use_interleaver);
     COMM_TransmitData(output_buffer, CALC_LEN, COMM_USB);
 
     if (cfg->mod_demod_method == MOD_DEMOD_FSK) {

--- a/Application/Src/MESS/mess_interleaver.c
+++ b/Application/Src/MESS/mess_interleaver.c
@@ -1,0 +1,135 @@
+/*
+ * mess_interleaver.c
+ *
+ *  Created on: Jun 1, 2025
+ *      Author: ericv
+ */
+
+/*
+ * Notes on interleaver:
+ * 1. The interleaver can only be applied to a stream of bits if the length is
+ * not a multiple of the interleaver depth
+ * 2. Following the JANUS standard (ANEP-87,) the preamble and the message
+ * cargo is interleaved separately
+ */
+
+/* Private includes ----------------------------------------------------------*/
+
+#include "mess_interleaver.h"
+#include "mess_packet.h"
+#include <stdbool.h>
+
+/* Private typedef -----------------------------------------------------------*/
+
+
+
+/* Private define ------------------------------------------------------------*/
+
+#define INTERLEAVER_DEPTH   13 // Same as JANUS (ANEP-87)
+
+/* Private macro -------------------------------------------------------------*/
+
+
+
+/* Private variables ---------------------------------------------------------*/
+
+
+
+/* Private function prototypes -----------------------------------------------*/
+
+// These functions directly modify the input bit message. Both functions are
+// nearly identical besides changing the original/destination indices
+bool interleave(uint16_t start_index, uint16_t length,
+    BitMessage_t* input_bit_msg, BitMessage_t* buffer_bit_msg);
+bool deinterleave(uint16_t start_index, uint16_t length,
+    BitMessage_t* input_bit_msg, BitMessage_t* buffer_bit_msg);
+
+
+/* Exported function definitions ---------------------------------------------*/
+
+bool Interleaver_Apply(BitMessage_t* bit_msg, const DspConfig_t* cfg)
+{
+  if (cfg->use_interleaver == false) {
+    return true;
+  }
+  // First interleave the preamble separately
+  BitMessage_t buffer_bit_msg;
+  if (interleave(bit_msg->preamble.ecc_start_index, bit_msg->preamble.ecc_len,
+                 bit_msg, &buffer_bit_msg) == false) {
+    return false;
+  }
+
+  // Then interleave the message cargo separately
+  if (interleave(bit_msg->cargo.ecc_start_index, bit_msg->cargo.ecc_len,
+                 bit_msg, &buffer_bit_msg) == false) {
+    return false;
+  }
+  return true;
+}
+
+bool Interleaver_Undo(BitMessage_t* bit_msg, const DspConfig_t* cfg, bool is_preamble)
+{
+  if (cfg->use_interleaver == false) {
+    return true;
+  }
+  BitMessage_t buffer_bit_msg;
+  SectionInfo_t section_info = is_preamble ? bit_msg->preamble : bit_msg->cargo;
+
+  return deinterleave(section_info.ecc_start_index, section_info.ecc_len,
+      bit_msg, &buffer_bit_msg);
+}
+
+/* Private function definitions ----------------------------------------------*/
+
+bool interleave(uint16_t start_index, uint16_t length,
+    BitMessage_t* input_bit_msg, BitMessage_t* buffer_bit_msg)
+{
+  if ((length % INTERLEAVER_DEPTH) == 0) {
+    return false;
+  }
+
+  for (uint16_t i = 0; i < length; i++) {
+    // Values are 32 bits to handle intermediate results
+    uint32_t original_index = start_index + i;
+    uint32_t new_index = (i * INTERLEAVER_DEPTH) % length + start_index;
+    bool bit;
+    if (Packet_GetBit(input_bit_msg, (uint16_t) original_index, &bit) == false) {
+      return false;
+    }
+    if (Packet_SetBit(buffer_bit_msg, (uint16_t) new_index, bit) == false) {
+      return false;
+    }
+  }
+
+  if (Packet_Copy(buffer_bit_msg, input_bit_msg, start_index, length) == false) {
+    return false;
+  }
+  return true;
+}
+
+bool deinterleave(uint16_t start_index, uint16_t length,
+    BitMessage_t* input_bit_msg, BitMessage_t* buffer_bit_msg)
+{
+  if ((length % INTERLEAVER_DEPTH) == 0) {
+    return false;
+  }
+
+  for (uint16_t i = 0; i < length; i++) {
+    // Values are 32 bits to handle intermediate results
+    uint32_t new_index = start_index + i;
+    uint32_t original_index = (i * INTERLEAVER_DEPTH) % length + start_index;
+    bool bit;
+    if (Packet_GetBit(input_bit_msg, (uint16_t) original_index, &bit) == false) {
+      return false;
+    }
+    if (Packet_SetBit(buffer_bit_msg, (uint16_t) new_index, bit) == false) {
+      return false;
+    }
+  }
+
+  if (Packet_Copy(buffer_bit_msg, input_bit_msg, start_index, length) == false) {
+    return false;
+  }
+
+  return true;
+}

--- a/Application/Src/MESS/mess_interleaver.c
+++ b/Application/Src/MESS/mess_interleaver.c
@@ -5,14 +5,6 @@
  *      Author: ericv
  */
 
-/*
- * Notes on interleaver:
- * 1. The interleaver can only be applied to a stream of bits if the length is
- * not a multiple of the interleaver depth
- * 2. Following the JANUS standard (ANEP-87,) the preamble and the message
- * cargo is interleaved separately
- */
-
 /* Private includes ----------------------------------------------------------*/
 
 #include "mess_interleaver.h"
@@ -25,7 +17,7 @@
 
 /* Private define ------------------------------------------------------------*/
 
-#define INTERLEAVER_DEPTH   13 // Same as JANUS (ANEP-87)
+
 
 /* Private macro -------------------------------------------------------------*/
 
@@ -33,16 +25,24 @@
 
 /* Private variables ---------------------------------------------------------*/
 
+// First 50 prime numbers
+static uint16_t primes[] = {
+    2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71,
+    73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151,
+    157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229
+};
 
+static const uint16_t num_primes = sizeof(primes) / sizeof(primes[0]);
 
 /* Private function prototypes -----------------------------------------------*/
 
 // These functions directly modify the input bit message. Both functions are
 // nearly identical besides changing the original/destination indices
-bool interleave(uint16_t start_index, uint16_t length,
+static bool interleave(uint16_t start_index, uint16_t length,
     BitMessage_t* input_bit_msg, BitMessage_t* buffer_bit_msg);
-bool deinterleave(uint16_t start_index, uint16_t length,
+static bool deinterleave(uint16_t start_index, uint16_t length,
     BitMessage_t* input_bit_msg, BitMessage_t* buffer_bit_msg);
+static uint16_t findInterleavingDepth(uint16_t length);
 
 
 /* Exported function definitions ---------------------------------------------*/
@@ -52,7 +52,7 @@ bool Interleaver_Apply(BitMessage_t* bit_msg, const DspConfig_t* cfg)
   if (cfg->use_interleaver == false) {
     return true;
   }
-  // First interleave the preamble separately
+  // First interleave the preamble separately following the JANUS standard
   BitMessage_t buffer_bit_msg;
   if (interleave(bit_msg->preamble.ecc_start_index, bit_msg->preamble.ecc_len,
                  bit_msg, &buffer_bit_msg) == false) {
@@ -84,14 +84,17 @@ bool Interleaver_Undo(BitMessage_t* bit_msg, const DspConfig_t* cfg, bool is_pre
 bool interleave(uint16_t start_index, uint16_t length,
     BitMessage_t* input_bit_msg, BitMessage_t* buffer_bit_msg)
 {
-  if ((length % INTERLEAVER_DEPTH) == 0) {
+  // If the length and the interleaver depth have a common denominator other
+  // than 1, the interleaver will result in duplicate entries and lost data
+  uint16_t interleaver_depth = findInterleavingDepth(length);
+  if ((length % interleaver_depth) == 0) {
     return false;
   }
 
   for (uint16_t i = 0; i < length; i++) {
     // Values are 32 bits to handle intermediate results
     uint32_t original_index = start_index + i;
-    uint32_t new_index = (i * INTERLEAVER_DEPTH) % length + start_index;
+    uint32_t new_index = (i * interleaver_depth) % length + start_index;
     bool bit;
     if (Packet_GetBit(input_bit_msg, (uint16_t) original_index, &bit) == false) {
       return false;
@@ -110,14 +113,17 @@ bool interleave(uint16_t start_index, uint16_t length,
 bool deinterleave(uint16_t start_index, uint16_t length,
     BitMessage_t* input_bit_msg, BitMessage_t* buffer_bit_msg)
 {
-  if ((length % INTERLEAVER_DEPTH) == 0) {
+  // If the length and the interleaver depth have a common denominator other
+  // than 1, the interleaver will result in duplicate entries and lost data
+  uint16_t interleaver_depth = findInterleavingDepth(length);
+  if ((length % interleaver_depth) == 0) {
     return false;
   }
 
   for (uint16_t i = 0; i < length; i++) {
     // Values are 32 bits to handle intermediate results
+    uint32_t original_index = (i * interleaver_depth) % length + start_index;
     uint32_t new_index = start_index + i;
-    uint32_t original_index = (i * INTERLEAVER_DEPTH) % length + start_index;
     bool bit;
     if (Packet_GetBit(input_bit_msg, (uint16_t) original_index, &bit) == false) {
       return false;
@@ -132,4 +138,34 @@ bool deinterleave(uint16_t start_index, uint16_t length,
   }
 
   return true;
+}
+
+/**
+ * Following the JANUS standard (ANEP-87)The interleaver depth (D) must meet
+ * the following two criteria:
+ * 1. D^2 > L where L is the length of the section with ECC
+ * 2. D is not a factor of L
+ */
+uint16_t findInterleavingDepth(uint16_t length)
+{
+  for (uint16_t i = 0; i < num_primes; i++) {
+    uint16_t candidate_prime = primes[i];
+    if (candidate_prime * candidate_prime <= length) {
+      continue;
+    }
+
+    if (length % candidate_prime != 0) {
+      return candidate_prime;
+    }
+  }
+
+  // No message should ever get here, but if it somehow does, remove condition 1
+  for (uint16_t i = num_primes - 1; i > 0; i++) {
+    uint16_t candidate_prime = primes[i];
+    if (length % candidate_prime != 0) {
+      return candidate_prime;
+    }
+  }
+  // Absolutely no messages should ever get here
+  return 1; // no interleaving
 }

--- a/Application/Src/MESS/mess_packet.c
+++ b/Application/Src/MESS/mess_packet.c
@@ -35,7 +35,7 @@ static bool is_stationary = DEFAULT_STATIONARY_FLAG;
 
 bool addPreamble(BitMessage_t* bit_msg, Message_t* msg);
 bool addMessage(BitMessage_t* bit_msg, Message_t* msg);
-void initPacket(BitMessage_t* bit_msg);
+void initPacket(BitMessage_t* bit_msg, const DspConfig_t* cfg);
 bool addChunk(BitMessage_t* bit_msg, uint8_t chunk, uint8_t chunk_size);
 bool addData(BitMessage_t* bit_msg, void* data, uint8_t num_bits);
 bool getData(BitMessage_t* bit_msg, uint16_t* start_position, uint8_t num_bits, void* data);
@@ -48,7 +48,7 @@ bool Packet_PrepareTx(Message_t* msg, BitMessage_t* bit_msg, const DspConfig_t* 
     return false;
   }
 
-  initPacket(bit_msg);
+  initPacket(bit_msg, cfg);
 
   // Add preamble to bit packet
   if (msg->data_type != EVAL) {
@@ -71,12 +71,14 @@ bool Packet_PrepareTx(Message_t* msg, BitMessage_t* bit_msg, const DspConfig_t* 
     }
   }
 
+  bit_msg->cargo.ecc_len = ErrorCorrection_GetLength(bit_msg->cargo.raw_len, cfg->ecc_method_message);
+
   return true;
 }
 
-bool Packet_PrepareRx(BitMessage_t* bit_msg)
+bool Packet_PrepareRx(BitMessage_t* bit_msg, const DspConfig_t* cfg)
 {
-  initPacket(bit_msg);
+  initPacket(bit_msg, cfg);
 
   return true;
 }
@@ -91,7 +93,7 @@ bool Packet_AddBit(BitMessage_t* bit_msg, bool bit)
   return true;
 }
 
-bool Packet_GetBit(BitMessage_t* bit_msg, uint16_t position, bool* bit)
+bool Packet_GetBit(const BitMessage_t* bit_msg, uint16_t position, bool* bit)
 {
   if (position >= bit_msg->bit_count) {
     return false;
@@ -177,7 +179,7 @@ bool Packet_FlipBit(BitMessage_t* bit_msg, uint16_t bit_index)
 
 bool Packet_SetBit(BitMessage_t* bit_msg, uint16_t bit_index, bool bit)
 {
-  if (bit_msg->bit_count >= PACKET_MAX_LENGTH_BYTES * 8) {
+  if (bit_index >= PACKET_MAX_LENGTH_BYTES * 8) {
     return false;
   }
 
@@ -236,6 +238,20 @@ uint16_t Packet_MinimumSize(uint16_t str_len)
   return packet_size;
 }
 
+bool Packet_Copy(const BitMessage_t* src_msg, BitMessage_t* dest_msg, const uint16_t start_index, const uint16_t length)
+{
+  for (uint16_t i = start_index; i < start_index + length; i++) {
+    bool bit;
+    if (Packet_GetBit(src_msg, i, &bit) == false) {
+      return false;
+    }
+    if (Packet_SetBit(dest_msg, i, bit) == false) {
+      return false;
+    }
+  }
+  return true;
+}
+
 bool Packet_RegisterParams()
 {
   uint32_t min_u32 = MIN_ID;
@@ -257,14 +273,25 @@ bool Packet_RegisterParams()
 
 /* Private function definitions ----------------------------------------------*/
 
-void initPacket(BitMessage_t* bit_msg)
+void initPacket(BitMessage_t* bit_msg, const DspConfig_t* cfg)
 {
   memset(bit_msg->data, 0, sizeof(bit_msg->data));
   bit_msg->bit_count = 0;
   bit_msg->sender_id = 255;
   bit_msg->contents_data_type = UNKNOWN;
   bit_msg->final_length = 0;
-  bit_msg->preamble_length_ecc = 0;
+
+  bit_msg->preamble.raw_len = PACKET_PREAMBLE_LENGTH_BITS;
+  bit_msg->preamble.ecc_len = ErrorCorrection_GetLength(bit_msg->preamble.raw_len, cfg->ecc_method_preamble);
+  bit_msg->preamble.raw_start_index = 0;
+  bit_msg->preamble.ecc_start_index = 0;
+
+  // Cant calculate lengths without decoding the preamble first
+  bit_msg->cargo.raw_len = 0;
+  bit_msg->cargo.ecc_len = 0;
+  bit_msg->cargo.raw_start_index = bit_msg->preamble.raw_start_index + bit_msg->preamble.raw_len;
+  bit_msg->cargo.ecc_start_index = bit_msg->preamble.ecc_start_index + bit_msg->preamble.ecc_len;
+
   bit_msg->stationary_flag = false;
   bit_msg->preamble_received = false;
   bit_msg->fully_received = false;
@@ -298,6 +325,7 @@ bool addPreamble(BitMessage_t* bit_msg, Message_t* msg)
   }
 
   bit_msg->final_length += length_accomodated;
+  bit_msg->cargo.raw_len = length_accomodated; // modified later
 
   if (Packet_AddBit(bit_msg, is_stationary) == false) {
     return false;
@@ -383,4 +411,3 @@ bool getData(BitMessage_t* bit_msg, uint16_t* start_position, uint8_t num_bits, 
   *start_position += num_bits;
   return true;
 }
-// TODO: Add the error correction codes to the messages. Implement error correction functions to find crcs and checksums

--- a/Application/Src/MESS/mess_packet.c
+++ b/Application/Src/MESS/mess_packet.c
@@ -219,8 +219,8 @@ bool Packet_Compare(const BitMessage_t* msg1, const BitMessage_t* msg2, bool* id
     return true;
   }
 
-  uint8_t last_byte1 = msg1->data[byte_count] >> (7 - remaining_bits);
-  uint8_t last_byte2 = msg2->data[byte_count] >> (7 - remaining_bits);
+  uint8_t last_byte1 = msg1->data[byte_count] >> (8 - remaining_bits);
+  uint8_t last_byte2 = msg2->data[byte_count] >> (8 - remaining_bits);
 
   *identical = last_byte1 == last_byte2;
   return true;

--- a/Application/Src/MESS/mess_packet.c
+++ b/Application/Src/MESS/mess_packet.c
@@ -71,7 +71,9 @@ bool Packet_PrepareTx(Message_t* msg, BitMessage_t* bit_msg, const DspConfig_t* 
     }
   }
 
+  bit_msg->combined_message_len = bit_msg->preamble.raw_len + bit_msg->cargo.raw_len;
   bit_msg->cargo.ecc_len = ErrorCorrection_GetLength(bit_msg->cargo.raw_len, cfg->ecc_method_message);
+  bit_msg->final_length = bit_msg->preamble.ecc_len + bit_msg->cargo.ecc_len;
 
   return true;
 }


### PR DESCRIPTION
Added an interleaver compliant with the JANUS ANEP-87 standard. The interleaver depth is dynamic and depends on the length of the message. Also added relevant tests to the feedback tests and added option to toggle interleaver from the HMI.

Threw in a slight refactor of tracking message lengths to make it more consistent. This could use more work as there is a lot of redundant code and the implementation is fractured