### PR TITLE
Goertzel-based synchronization

### DIFF
--- a/Application/Inc/COMM/comm_menu_system.h
+++ b/Application/Inc/COMM/comm_menu_system.h
@@ -106,6 +106,7 @@ typedef enum {
   MENU_ID_DBG_TEMP,             // Current temperature
   MENU_ID_DBG_ERR,              // Current errors
   MENU_ID_DBG_PWR,              // Current power consumption
+  MENU_ID_DBG_NOISE,            // Scaleless background noise level
   MENU_ID_DBG_DFU,              // Enter DFU mode to flash new firmware over USB
   MENU_ID_DBG_RESETCONFIG,      // Reset saved configuration 
   MENU_ID_HIST_PWR,             // History of power

--- a/Application/Inc/MESS/mess_background_noise.h
+++ b/Application/Inc/MESS/mess_background_noise.h
@@ -35,9 +35,29 @@ extern "C" {
 
 /* Exported functions prototypes ---------------------------------------------*/
 
+/**
+ * @brief Restarts the background noise and invalidates the current background
+ * noise measurement
+ */
 void BackgroundNoise_Reset();
+
+/**
+ * @brief Calculates the background noise in band on the most recent data
+ */
 void BackgroundNoise_Calculate();
+
+/**
+ * @brief Returns the calculated background noise
+ * 
+ * @return float Background noise (scaleless)
+ */
 float BackgroundNoise_Get();
+
+/**
+ * @brief Whether enough samples have been analyzed for a background noise calculation
+ * 
+ * @return true if ready, false otherwise
+ */
 bool BackgroundNoise_Ready();
 
 /* Private defines -----------------------------------------------------------*/

--- a/Application/Inc/MESS/mess_background_noise.h
+++ b/Application/Inc/MESS/mess_background_noise.h
@@ -1,12 +1,12 @@
 /*
- * goertzel.h
+ * mess_background_noise.h
  *
- *  Created on: Jul 13, 2025
+ *  Created on: Jul 14, 2025
  *      Author: ericv
  */
 
-#ifndef COMMON_UTILS_GOERTZEL_H_
-#define COMMON_UTILS_GOERTZEL_H_
+#ifndef MESS_MESS_BACKGROUND_NOISE_H_
+#define MESS_MESS_BACKGROUND_NOISE_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,16 +22,7 @@ extern "C" {
 
 /* Exported types ------------------------------------------------------------*/
 
-typedef struct {
-  uint16_t buf_len;
-  uint16_t data_len;
-  uint16_t start_pos;
-  uint32_t* f;
-  float* e_f;
-  float* window;
-  float energy_normalization;
-  uint16_t window_size;
-} GoertzelInfo_t;
+
 
 /* Exported constants --------------------------------------------------------*/
 
@@ -43,9 +34,9 @@ typedef struct {
 
 /* Exported functions prototypes ---------------------------------------------*/
 
-void goertzel_1(GoertzelInfo_t* goertzel_info);
-void goertzel_2(GoertzelInfo_t* goertzel_info);
-void goertzel_6(GoertzelInfo_t* goertzel_info);
+void BackgroundNoise_Reset();
+void BackgroundNoise_Calculate();
+float BackgroundNoise_Get();
 
 /* Private defines -----------------------------------------------------------*/
 
@@ -53,4 +44,4 @@ void goertzel_6(GoertzelInfo_t* goertzel_info);
 }
 #endif
 
-#endif /* COMMON_UTILS_GOERTZEL_H_ */
+#endif /* MESS_MESS_BACKGROUND_NOISE_H_ */

--- a/Application/Inc/MESS/mess_background_noise.h
+++ b/Application/Inc/MESS/mess_background_noise.h
@@ -15,6 +15,7 @@ extern "C" {
 /* Includes ------------------------------------------------------------------*/
 
 #include <stdint.h>
+#include <stdbool.h>
 
 /* Private includes ----------------------------------------------------------*/
 
@@ -37,6 +38,7 @@ extern "C" {
 void BackgroundNoise_Reset();
 void BackgroundNoise_Calculate();
 float BackgroundNoise_Get();
+bool BackgroundNoise_Ready();
 
 /* Private defines -----------------------------------------------------------*/
 

--- a/Application/Inc/MESS/mess_demodulate.h
+++ b/Application/Inc/MESS/mess_demodulate.h
@@ -85,6 +85,8 @@ void Demodulate_Init();
  */
 bool Demodulate_Perform(DemodulationInfo_t* data, const DspConfig_t* cfg);
 
+float Demodulate_PowerNormalization();
+
 /**
  * @brief Registers demodulation parameters with the parameter management system
  *

--- a/Application/Inc/MESS/mess_demodulate.h
+++ b/Application/Inc/MESS/mess_demodulate.h
@@ -85,6 +85,12 @@ void Demodulate_Init();
  */
 bool Demodulate_Perform(DemodulationInfo_t* data, const DspConfig_t* cfg);
 
+/**
+ * @brief Power normalization factor for current windowing function
+ * 
+ * @return float Normalization factor that the power must be multiplied by
+ * to normalize
+ */
 float Demodulate_PowerNormalization();
 
 /**

--- a/Application/Inc/MESS/mess_sync.h
+++ b/Application/Inc/MESS/mess_sync.h
@@ -58,13 +58,20 @@ bool Sync_GetStep(const DspConfig_t* cfg, WaveformStep_t* waveform_step, bool* b
 uint16_t Sync_NumSteps(const DspConfig_t* cfg);
 
 /**
- * @brief Syncrhonizes the receiver and sender (NOT IMPLEMENTED YET)
+ * @brief Synchronizes the receiver and sender (NOT IMPLEMENTED YET)
  * 
  * @param cfg 
  * @return true 
  * @return false 
  */
 bool Sync_Synchronize(const DspConfig_t* cfg);
+
+/**
+ * @brief Resets the synchornization process
+ * 
+ * To be called when a message has been started to reset
+ */
+void Sync_Reset();
 
 /* Private defines -----------------------------------------------------------*/
 

--- a/Application/Inc/common/utils/goertzel.h
+++ b/Application/Inc/common/utils/goertzel.h
@@ -1,0 +1,55 @@
+/*
+ * goertzel.h
+ *
+ *  Created on: Jul 13, 2025
+ *      Author: ericv
+ */
+
+#ifndef COMMON_UTILS_GOERTZEL_H_
+#define COMMON_UTILS_GOERTZEL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+
+#include <stdint.h>
+
+/* Private includes ----------------------------------------------------------*/
+
+
+
+/* Exported types ------------------------------------------------------------*/
+
+typedef struct {
+  uint16_t buf_len;
+  uint16_t data_len;
+  uint16_t start_pos;
+  uint32_t* f;
+  float* e_f;
+  float* window;
+  uint16_t window_size;
+} GoertzelInfo_t;
+
+/* Exported constants --------------------------------------------------------*/
+
+
+
+/* Exported macro ------------------------------------------------------------*/
+
+
+
+/* Exported functions prototypes ---------------------------------------------*/
+
+void goertzel_1(GoertzelInfo_t* goertzel_info);
+void goertzel_2(GoertzelInfo_t* goertzel_info);
+void goertzel_6(GoertzelInfo_t* goertzel_info);
+
+/* Private defines -----------------------------------------------------------*/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* COMMON_UTILS_GOERTZEL_H_ */

--- a/Application/Inc/common/utils/goertzel.h
+++ b/Application/Inc/common/utils/goertzel.h
@@ -43,8 +43,25 @@ typedef struct {
 
 /* Exported functions prototypes ---------------------------------------------*/
 
+/**
+ * @brief Calculates goertzel on a single frequency
+ * 
+ * @param goertzel_info Contains input and output info for goertzel calculation
+ */
 void goertzel_1(GoertzelInfo_t* goertzel_info);
+
+/**
+ * @brief Calculates goertzel on 2 frequencies together
+ * 
+ * @param goertzel_info Contains input and output info for goertzel calculation
+ */
 void goertzel_2(GoertzelInfo_t* goertzel_info);
+
+/**
+ * @brief Calculates goertzel on 6 frequencies at once
+ * 
+ * @param goertzel_info Contains input and output info for goertzel calculation
+ */
 void goertzel_6(GoertzelInfo_t* goertzel_info);
 
 /* Private defines -----------------------------------------------------------*/

--- a/Application/Src/MESS/mess_adc.c
+++ b/Application/Src/MESS/mess_adc.c
@@ -10,6 +10,7 @@
 #include "mess_adc.h"
 #include "mess_input.h"
 #include "mess_feedback.h"
+#include "mess_background_noise.h"
 #include "sys_temperature.h"
 #include "stm32h7xx_hal.h"
 #include <string.h>
@@ -87,6 +88,7 @@ bool ADC_StartInput()
   input_head_pos = 0;
   input_tail_pos = 0;
   HAL_TIM_Base_Start(&htim8);
+  BackgroundNoise_Reset();
   HAL_StatusTypeDef ret = HAL_ADC_Start_DMA(&INPUT_ADC, (uint32_t*) adc_buffer, ADC_BUFFER_SIZE);
   return ret == HAL_OK;
 }

--- a/Application/Src/MESS/mess_background_noise.c
+++ b/Application/Src/MESS/mess_background_noise.c
@@ -1,0 +1,109 @@
+/*
+ * mess_background_noise.c
+ *
+ *  Created on: Jul 14, 2025
+ *      Author: ericv
+ */
+
+/* Private includes ----------------------------------------------------------*/
+
+#include "mess_background_noise.h"
+#include "mess_adc.h"
+#include "mess_demodulate.h"
+#include "arm_math.h"
+#include <stdint.h>
+
+/* Private typedef -----------------------------------------------------------*/
+
+typedef struct {
+  float accumulated_energy;
+  uint16_t counts;
+} EnergyHistory_t;
+
+/* Private define ------------------------------------------------------------*/
+
+#define NOISE_BUFFER_SIZE   128
+#define MS_PER_ENTRY        100
+#define COUNTS_PER_ENTRY    (ADC_SAMPLING_RATE * MS_PER_ENTRY / 1000 / NOISE_BUFFER_SIZE)
+#define NOISE_HISTORY_SIZE  10
+
+#define NUM_NOISE_IN_AVERAGE  30
+
+#define WINDOW_INCREMENT      4
+
+/* Private macro -------------------------------------------------------------*/
+
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+
+/* Private variables ---------------------------------------------------------*/
+
+extern arm_rfft_fast_instance_f32 fft_handle128;
+
+static bool energy_ready = false;
+
+static EnergyHistory_t energy_history[NOISE_HISTORY_SIZE];
+
+static volatile float in_band_noise = 0.0f;
+static uint16_t noise_buffer_tail = 0;
+static uint16_t noise_history_index = 0;
+static uint16_t accumulated_noise_entries = 0;
+
+/* Private function prototypes -----------------------------------------------*/
+
+
+
+/* Exported function definitions ---------------------------------------------*/
+
+void BackgroundNoise_Reset()
+{
+  noise_buffer_tail = 0;
+  accumulated_noise_entries = 0;
+  noise_history_index = 0;
+  in_band_noise = 0.0f;
+  energy_ready = false;
+}
+
+void BackgroundNoise_Calculate()
+{
+  uint16_t head = ADC_InputGetHead();
+  while (((head - noise_buffer_tail) & PROCESSING_BUFFER_MASK) > NOISE_BUFFER_SIZE) {
+    float fft_in_buf[NOISE_BUFFER_SIZE];
+    float fft_out_buf[NOISE_BUFFER_SIZE];
+
+    for (uint16_t i = 0; i < NOISE_BUFFER_SIZE; i++) {
+      uint16_t index = (noise_buffer_tail + i) & PROCESSING_BUFFER_MASK;
+      fft_in_buf[i] = ADC_InputGetDataAbsolute(index);
+    }
+    arm_rfft_fast_f32(&fft_handle128, fft_in_buf, fft_out_buf, 0);
+
+    for (uint16_t j = 28; j < 39; j++) {
+      float real = fft_out_buf[2 * j];
+      float imag = fft_out_buf[2 * j + 1];
+
+      // Normalize to PSD (P/Hz)
+      float mag = (real * real + imag * imag) / NOISE_BUFFER_SIZE;
+      
+      energy_history[noise_history_index].accumulated_energy += mag / 12;
+    }
+    energy_history[noise_history_index].counts++;
+    if (energy_history[noise_history_index].counts >= COUNTS_PER_ENTRY) {
+      if (noise_history_index == 9 || accumulated_noise_entries != 0) {
+        float energy = energy_history[noise_history_index].accumulated_energy / energy_history[noise_history_index].counts;
+        in_band_noise = (in_band_noise * accumulated_noise_entries + energy) / (accumulated_noise_entries + 1);
+        accumulated_noise_entries = MIN(accumulated_noise_entries + 1, NUM_NOISE_IN_AVERAGE);
+        energy_ready = accumulated_noise_entries == NUM_NOISE_IN_AVERAGE;
+      }
+      noise_history_index = (noise_history_index + 1) % NOISE_HISTORY_SIZE;
+      energy_history[noise_history_index].counts = 0;
+      energy_history[noise_history_index].accumulated_energy = 0.0f;
+    }
+    noise_buffer_tail = (noise_buffer_tail + NOISE_BUFFER_SIZE) & PROCESSING_BUFFER_MASK;
+  }
+}
+
+float BackgroundNoise_Get()
+{
+  return in_band_noise;
+}
+
+/* Private function definitions ----------------------------------------------*/

--- a/Application/Src/MESS/mess_demodulate.c
+++ b/Application/Src/MESS/mess_demodulate.c
@@ -54,7 +54,7 @@ static DemodulationHistory_t demodulation_history[NUM_DEMODULATION_HISTORY][MAX_
 static float significant_shift_threshold = DEFAULT_HIST_CMP_THRESH;
 
 static WindowFunction_t window_function = DEFAULT_WINDOW_FUNCTION;
-static float window[WINDOW_FUNCTION_SIZE];
+float window[WINDOW_FUNCTION_SIZE];
 
 /* Private function prototypes -----------------------------------------------*/
 
@@ -81,6 +81,7 @@ bool Demodulate_Perform(DemodulationInfo_t* data, const DspConfig_t* cfg)
       float e_f[2];
       goertzel_info.f = f;
       goertzel_info.e_f = e_f;
+      goertzel_info.energy_normalization = Demodulate_PowerNormalization();
 
       goertzel_2(&goertzel_info);
 
@@ -96,9 +97,10 @@ bool Demodulate_Perform(DemodulationInfo_t* data, const DspConfig_t* cfg)
       float e_f[2];
       goertzel_info.f = f;
       goertzel_info.e_f = e_f;
+      goertzel_info.energy_normalization = Demodulate_PowerNormalization();
 
       goertzel_2(&goertzel_info);
-      
+
       data->analysis_done = true;
       data->decoded_bit = (goertzel_info.e_f[0] > goertzel_info.e_f[1]) ? false : true;
       break;
@@ -176,6 +178,20 @@ bool Demodulate_Perform(DemodulationInfo_t* data, const DspConfig_t* cfg)
       return false;
   }
   return true;
+}
+
+float Demodulate_PowerNormalization()
+{
+  switch (window_function) {
+    case WINDOW_RECTANGULAR:
+      return 1.0f;
+    case WINDOW_HANN:
+      return 1.63f;
+    case WINDOW_HAMMING:
+      return 1.59;
+    default:
+      return 1.0f;
+  }
 }
 
 bool Demodulate_RegisterParams()

--- a/Application/Src/MESS/mess_demodulate.c
+++ b/Application/Src/MESS/mess_demodulate.c
@@ -188,7 +188,7 @@ float Demodulate_PowerNormalization()
     case WINDOW_HANN:
       return 1.63f;
     case WINDOW_HAMMING:
-      return 1.59;
+      return 1.59f;
     default:
       return 1.0f;
   }

--- a/Application/Src/MESS/mess_input.c
+++ b/Application/Src/MESS/mess_input.c
@@ -107,7 +107,7 @@ static uint16_t fft_analysis_index = 0;
 static uint16_t fft_analysis_length = 0;
 
 static arm_rfft_fast_instance_f32 fft_handle64;
-static arm_rfft_fast_instance_f32 fft_handle128;
+arm_rfft_fast_instance_f32 fft_handle128;
 
 static FrequencyThresholds_t frequency_thresholds[] = {
     {.raw_amplitude_threshold = 80, .length_us = 2500},

--- a/Application/Src/MESS/mess_input.c
+++ b/Application/Src/MESS/mess_input.c
@@ -421,7 +421,7 @@ void Input_NoiseFft()
 
   for (uint16_t i = 0; i < NOISE_FFT_SAMPLES; i += NOISE_FFT_BLOCK_SIZE) {
     for (uint16_t j = 0; j < NOISE_FFT_BLOCK_SIZE; j++) {
-      fft_in_buf[i] = ADC_InputGetData(i);
+      fft_in_buf[j] = ADC_InputGetData(i + j);
     }
     arm_rfft_fast_f32(&fft_handle128, fft_in_buf, fft_out_buf, 0);
 

--- a/Application/Src/MESS/mess_main.c
+++ b/Application/Src/MESS/mess_main.c
@@ -24,6 +24,7 @@
 #include "mess_feedback_tests.h"
 #include "mess_interleaver.h"
 #include "mess_cargo.h"
+#include "mess_background_noise.h"
 
 #include "sys_error.h"
 
@@ -201,6 +202,8 @@ void MESS_StartTask(void* argument)
           switchState(PROCESSING);
           break;
         }
+
+        BackgroundNoise_Calculate();
         break;
       case PROCESSING:
         // Process ADC input data only

--- a/Application/Src/MESS/mess_main.c
+++ b/Application/Src/MESS/mess_main.c
@@ -25,6 +25,7 @@
 #include "mess_interleaver.h"
 #include "mess_cargo.h"
 #include "mess_background_noise.h"
+#include "mess_sync.h"
 
 #include "sys_error.h"
 
@@ -198,7 +199,7 @@ void MESS_StartTask(void* argument)
           }
         }
 
-        if (Input_DetectMessageStart(cfg) == true) {
+        if (Sync_Synchronize(cfg) == true) {
           switchState(PROCESSING);
           break;
         }
@@ -430,6 +431,7 @@ static void switchState(ProcessingState_t newState)
       switchTrReceive();
       osDelay(5);
       ADC_StartInput();
+      Sync_Reset();
       task_state = LISTENING;
       break;
     case PROCESSING:

--- a/Application/Src/MESS/mess_modulate.c
+++ b/Application/Src/MESS/mess_modulate.c
@@ -196,7 +196,7 @@ uint32_t Modulate_GetFhbfskFrequency(bool bit,
   uint32_t frequency_separation = (uint32_t) (cfg->fhbfsk_freq_spacing * cfg->baud_rate);
 
   uint32_t start_freq = cfg->fc - 
-      cfg->fhbfsk_freq_spacing * (2 * cfg->fhbfsk_num_tones - 1) / 2;
+      frequency_separation * (2 * cfg->fhbfsk_num_tones - 1) / 2;
   start_freq = (start_freq / frequency_separation) * frequency_separation;
 
   uint32_t sequence_number = getFhbfskSeqeunceNumber(bit_index / cfg->fhbfsk_dwell_time, cfg);

--- a/Application/Src/MESS/mess_preamble.c
+++ b/Application/Src/MESS/mess_preamble.c
@@ -218,6 +218,7 @@ bool Preamble_Decode(BitMessage_t* bit_msg, Message_t* msg, const DspConfig_t* c
       }
       break;
     default:
+      // In case message data is corrupted, this will return false
       return false;
   }
 

--- a/Application/Src/MESS/mess_sync.c
+++ b/Application/Src/MESS/mess_sync.c
@@ -41,6 +41,14 @@ typedef struct {
   uint8_t symbols_exceeding_threshold;
 } WindowedGoertzel_t;
 
+typedef struct {
+  uint16_t buffer_index;
+  uint16_t rollover_count;
+  float snr_score;
+  float uncapped_snr_score;
+  uint8_t symbols_exceeding_threshold;
+} Stage2Results_t;
+
 /* Private define ------------------------------------------------------------*/
 
 #define MIN_SYMBOLS_EXCEEDING_SNR 6
@@ -65,12 +73,20 @@ static uint32_t janus_frequencies[32];
 static uint16_t window_offsets[SYNC_STAGE_1_SUBDIVIDE];
 static uint16_t samples_per_symbol;
 static JanusPnStage_t sync_stage = PN_STAGE_1;
-static WindowedGoertzel_t stage_results[STAGE_RESULTS_LEN];
+static WindowedGoertzel_t stage1_results[STAGE_RESULTS_LEN];
 static uint16_t stage_results_head = 0;
 static uint16_t stage_results_len = 0;
 static uint16_t window_offset_index = 0;
 static uint16_t processed_buffer_tail = 0;
 static uint16_t processed_buffer_len = 0;
+
+static uint16_t stage1_rollover_index;
+static uint16_t stage1_buffer_index;
+
+static uint16_t stage2_offsets[SYNC_STAGE_1_SUBDIVIDE];
+static uint8_t stage2_fine_step = 0;
+static uint8_t stage2_frequency_index = 0;
+static Stage2Results_t stage2_results[SYNC_STAGE_234_SUBDIVIDE];
 
 static volatile bool sync_error = false;
 
@@ -80,11 +96,15 @@ static void updateParameters(const DspConfig_t* cfg);
 static bool janusPnStep(bool* bit, uint16_t step);
 static void fillJanusFrequencies(const DspConfig_t* cfg);
 static void fillWindowOffsets(const DspConfig_t* cfg);
-static bool janusPnSynchronize(const DspConfig_t* cfg);
-static void populateResultsStage1(uint16_t start_index, uint16_t end_index, const DspConfig_t* cfg);
-static void scoreOffsets(const DspConfig_t* cfg);
-static bool findGlobalMax(const DspConfig_t* cfg);
+static bool janusPnSynchronize();
+static void populateResultsStage1(uint16_t start_index, uint16_t end_index);
+static void scoreOffsets();
+static void findGlobalMax();
 static void stage1TailIncrement();
+static void fillStage2Results();
+static void waitSynchronizationComplete(uint16_t final_rollover_index, uint16_t final_buffer_index);
+static void populateGoertzelInfo(GoertzelInfo_t* goertzel_info);
+static bool evaluateStage2Results();
 
 /* Exported function definitions ---------------------------------------------*/
 
@@ -129,12 +149,15 @@ bool Sync_Synchronize(const DspConfig_t* cfg)
 
 void Sync_Reset()
 {
-  memset(stage_results, 0, sizeof(stage_results));
+  memset(stage1_results, 0, sizeof(stage1_results));
+  memset(stage2_results, 0, sizeof(stage2_results));
   stage_results_head = 0;
   stage_results_len = 0;
   window_offset_index = 0;
   processed_buffer_tail = 0;
   processed_buffer_len = 0;
+  stage2_fine_step = 0;
+  stage2_frequency_index = 0;
   sync_stage = PN_STAGE_1;
 }
 
@@ -182,16 +205,39 @@ void fillWindowOffsets(const DspConfig_t* cfg)
   for (uint8_t i = 0; i < SYNC_STAGE_1_SUBDIVIDE; i++) {
     window_offsets[i] = (i * offsets_increment) >> offsets_precision;
   }
+
+  // Stage 2 window goes from - 2 / stage1 subdivide : 2 / stage1 subdivide
+  // centered around the previous maximum correlation
+  uint16_t base_value = samples_per_symbol - ((offsets_increment * 2) >> offsets_precision);
+  offsets_increment = (offsets_increment * 4) / SYNC_STAGE_234_SUBDIVIDE;
+  for (uint8_t i = 0; i < SYNC_STAGE_234_SUBDIVIDE; i++) {
+    // skips the center index that was tested before
+    uint16_t index = (i > 7) ? (i + 1) : i;
+    stage2_offsets[i] = base_value + ((offsets_increment * index) >> offsets_precision);
+  }
 }
 
-bool janusPnSynchronize(const DspConfig_t* cfg)
+/**
+ * JANUS uses a 32-chip sequence to synchronize the sender and the receiver.
+ * The frequencies used are fixed making the synchronization process easier.
+ * The synchronization process is split into stages to make the process easier.
+ * There are 4 stages in total with each stage looking at 8 bits in the
+ * synchronization sequence. The first stage looking at bits 0-7 is the most
+ * coarse of the stages and is used to detect when a message has started. The
+ * following stages hone in on the start of the message and can also be used
+ * to estimate doppler effects. (doppler estiamation not implemented yet)
+ */
+bool janusPnSynchronize()
 {
   switch (sync_stage) {
     case PN_STAGE_1:
-      populateResultsStage1(0, 8, cfg);
-      scoreOffsets(cfg);
-      return findGlobalMax(cfg);
+      populateResultsStage1(0, 8);
+      scoreOffsets();
+      findGlobalMax();
+      break;
     case PN_STAGE_2:
+      fillStage2Results();
+      return evaluateStage2Results();
     case PN_STAGE_3:
     case PN_STAGE_4:
     case PN_STAGE_COMPLETE:
@@ -202,14 +248,10 @@ bool janusPnSynchronize(const DspConfig_t* cfg)
   return false;
 }
 
-void populateResultsStage1(uint16_t start_index, uint16_t end_index, const DspConfig_t* cfg)
+void populateResultsStage1(uint16_t start_index, uint16_t end_index)
 {
   GoertzelInfo_t goertzel_info;
-  goertzel_info.buf_len = PROCESSING_BUFFER_SIZE;
-  goertzel_info.data_len = samples_per_symbol;
-  goertzel_info.window = window;
-  goertzel_info.energy_normalization = Demodulate_PowerNormalization();
-  goertzel_info.window_size = 512;
+  populateGoertzelInfo(&goertzel_info);
   uint32_t f[6];
   goertzel_info.f = f;
   float e_f[6];
@@ -223,7 +265,7 @@ void populateResultsStage1(uint16_t start_index, uint16_t end_index, const DspCo
       }
       goertzel_6(&goertzel_info);
       for (uint8_t i = 0; i < 6; i++) {
-        stage_results[stage_results_head].energies[end_index - num_frequencies + 1 + i] = goertzel_info.e_f[i];
+        stage1_results[stage_results_head].energies[end_index - num_frequencies + 1 + i] = goertzel_info.e_f[i];
       }
       num_frequencies -= 6;
     }
@@ -234,7 +276,7 @@ void populateResultsStage1(uint16_t start_index, uint16_t end_index, const DspCo
       }
       goertzel_2(&goertzel_info);
       for (uint8_t i = 0; i < 2; i++) {
-        stage_results[stage_results_head].energies[end_index - num_frequencies + 1 + i] = goertzel_info.e_f[i];
+        stage1_results[stage_results_head].energies[end_index - num_frequencies + 1 + i] = goertzel_info.e_f[i];
       }
       num_frequencies -= 2;
     }
@@ -245,12 +287,12 @@ void populateResultsStage1(uint16_t start_index, uint16_t end_index, const DspCo
       }
       goertzel_1(&goertzel_info);
       for (uint8_t i = 0; i < 1; i++) {
-        stage_results[stage_results_head].energies[end_index - num_frequencies + 1 + i] = goertzel_info.e_f[i];
+        stage1_results[stage_results_head].energies[end_index - num_frequencies + 1 + i] = goertzel_info.e_f[i];
       }
       num_frequencies -= 1;
     }
-    stage_results[stage_results_head].buffer_index = goertzel_info.start_pos;
-    stage_results[stage_results_head].rollover_index = ADC_TailRolloverCount(false);
+    stage1_results[stage_results_head].buffer_index = goertzel_info.start_pos;
+    stage1_results[stage_results_head].rollover_index = ADC_TailRolloverCount(false);
     stage_results_head = (stage_results_head + 1) % STAGE_RESULTS_LEN;
     stage_results_len++;
     if (stage_results_len >= STAGE_RESULTS_LEN) {
@@ -261,7 +303,7 @@ void populateResultsStage1(uint16_t start_index, uint16_t end_index, const DspCo
   }
 }
 
-void scoreOffsets(const DspConfig_t* cfg)
+void scoreOffsets()
 {
   uint16_t results_per_stage = SYNC_STAGE_1_SUBDIVIDE * FREQUENCIES_PER_STAGE;
 
@@ -276,45 +318,45 @@ void scoreOffsets(const DspConfig_t* cfg)
     uint16_t base_index = (stage_results_head - stage_results_len) & (STAGE_RESULTS_LEN - 1);
     float snr = 0;
     float uncapped_snr = 0;
-    stage_results[base_index].symbols_exceeding_threshold = 0;
+    stage1_results[base_index].symbols_exceeding_threshold = 0;
     
     for (uint16_t i = 0; i < FREQUENCIES_PER_STAGE; i++) {
       uint16_t freq_index = (base_index + i * SYNC_STAGE_1_SUBDIVIDE) & (STAGE_RESULTS_LEN - 1);
-      float frequency_energy = stage_results[freq_index].energies[i];
+      float frequency_energy = stage1_results[freq_index].energies[i];
       // penalty for including the next bin
-      frequency_energy -= stage_results[freq_index].energies[i + 1];
+      frequency_energy -= stage1_results[freq_index].energies[i + 1];
       float snr_score = frequency_energy / background_noise;
       snr += MIN(snr_score, TARGET_SNR * 2);
       uncapped_snr += snr_score;
       if (snr_score >= TARGET_SNR) {
-        stage_results[base_index].symbols_exceeding_threshold++;
+        stage1_results[base_index].symbols_exceeding_threshold++;
       }
     }
     
     snr /= FREQUENCIES_PER_STAGE;
     uncapped_snr /= FREQUENCIES_PER_STAGE;
-    stage_results[base_index].snr_score = snr;
-    stage_results[base_index].uncapped_snr_score = uncapped_snr;
+    stage1_results[base_index].snr_score = snr;
+    stage1_results[base_index].uncapped_snr_score = uncapped_snr;
     stage_results_len--;
     processed_buffer_len++;
   }
 }
 
-bool findGlobalMax(const DspConfig_t* cfg)
+void findGlobalMax()
 {
   const uint16_t margin = 3;
   uint16_t best_index = 0;
   float best_snr = 0.0f;
 
   if (processed_buffer_len < margin) {
-    return false;
+    return;
   }
 
   for (uint16_t i = 0; i < processed_buffer_len; i++) {
     uint16_t results_index = (i + processed_buffer_tail) % STAGE_RESULTS_LEN;
-    float uncapped_snr = stage_results[results_index].uncapped_snr_score;
-    float capped_snr = stage_results[results_index].snr_score;
-    uint8_t num_exceeding = stage_results[results_index].symbols_exceeding_threshold;
+    float uncapped_snr = stage1_results[results_index].uncapped_snr_score;
+    float capped_snr = stage1_results[results_index].snr_score;
+    uint8_t num_exceeding = stage1_results[results_index].symbols_exceeding_threshold;
     if ((uncapped_snr > best_snr) && (num_exceeding >= MIN_SYMBOLS_EXCEEDING_SNR) && (capped_snr >= TARGET_SNR)) {
       best_snr = uncapped_snr;
       best_index = results_index;
@@ -327,7 +369,7 @@ bool findGlobalMax(const DspConfig_t* cfg)
     processed_buffer_len -= results_searched;
     processed_buffer_tail += results_searched;
     processed_buffer_tail %= STAGE_RESULTS_LEN;
-    return false;
+    return;
   }
   uint16_t distance_from_end = (processed_buffer_tail + processed_buffer_len - best_index) % STAGE_RESULTS_LEN;
   // Found a max but it is too close to the end.
@@ -335,30 +377,16 @@ bool findGlobalMax(const DspConfig_t* cfg)
     processed_buffer_len -= results_searched;
     processed_buffer_tail += results_searched;
     processed_buffer_tail %= STAGE_RESULTS_LEN;
-    return false;
+    return;
   }
 
-  uint32_t samples_to_wait = 32 * samples_per_symbol;
-
-  uint64_t current_samples = PROCESSING_BUFFER_SIZE * stage_results[best_index].rollover_index;
-  current_samples += stage_results[best_index].buffer_index;
-
-  uint64_t target_total_samples = current_samples + samples_to_wait;
-
-  uint16_t target_rollover = target_total_samples / PROCESSING_BUFFER_SIZE;
-  uint16_t target_samples = target_total_samples % PROCESSING_BUFFER_SIZE;
-
-  while (ADC_TailRolloverCount(false) < target_rollover) {
-    ADC_InputSetTail(ADC_InputGetHead());
-    osDelay(1);
-  }
-  ADC_InputSetTail(ADC_InputGetHead());
-  while (ADC_InputGetHead() < target_samples && (ADC_TailRolloverCount(false) == target_rollover)) {
-    ADC_InputSetTail(ADC_InputGetHead());
-    osDelay(1);
-  }
-  ADC_InputSetTail(target_samples);
-  return true;
+  stage1_rollover_index = stage1_results[best_index].rollover_index;
+  stage1_buffer_index = stage1_results[best_index].buffer_index;
+  sync_stage = PN_STAGE_2;
+  uint16_t new_tail = ((uint32_t) stage1_buffer_index + (FREQUENCIES_PER_STAGE - 1) * samples_per_symbol) % PROCESSING_BUFFER_SIZE;
+  new_tail += stage2_offsets[0];
+  new_tail %= PROCESSING_BUFFER_SIZE;
+  ADC_InputSetTail(new_tail); 
 }
 
 void stage1TailIncrement()
@@ -372,4 +400,116 @@ void stage1TailIncrement()
   }
   ADC_InputTailAdvance(increment_amount);
   window_offset_index = (window_offset_index + 1) % SYNC_STAGE_1_SUBDIVIDE;
+}
+
+void fillStage2Results()
+{
+  GoertzelInfo_t goertzel_info;
+  populateGoertzelInfo(&goertzel_info);
+
+  if (BackgroundNoise_Ready() == false) {
+    return;
+  }
+
+  float background_noise = BackgroundNoise_Get();
+
+  while (ADC_InputAvailableSamples() > samples_per_symbol) {
+    if (stage2_frequency_index == 0) {
+      stage2_results[stage2_fine_step].buffer_index = ADC_InputGetTail();
+      stage2_results[stage2_fine_step].rollover_count = ADC_TailRolloverCount(false);
+    }
+    goertzel_info.start_pos = ADC_InputGetTail();
+    uint32_t frequencies[2];
+    frequencies[0] = janus_frequencies[stage2_frequency_index + FREQUENCIES_PER_STAGE];
+    frequencies[1] = janus_frequencies[stage2_frequency_index + FREQUENCIES_PER_STAGE + 1];
+    goertzel_info.f = frequencies;
+    float e_f[2];
+    goertzel_info.e_f = e_f;
+    goertzel_2(&goertzel_info);
+    float frequency_energy = e_f[0];
+    // penalty for including the next bin
+    frequency_energy -= e_f[1];
+    float uncapped_snr = frequency_energy / background_noise;
+    float snr = MIN(uncapped_snr, TARGET_SNR * 2);
+    if (snr > TARGET_SNR) {
+      stage2_results[stage2_fine_step].symbols_exceeding_threshold++;
+    }
+    stage2_results[stage2_fine_step].snr_score += snr / FREQUENCIES_PER_STAGE;
+    stage2_results[stage2_fine_step].uncapped_snr_score += uncapped_snr / FREQUENCIES_PER_STAGE;
+    stage2_fine_step++;
+    // Check if done with stage 2
+    if ((stage2_fine_step == SYNC_STAGE_234_SUBDIVIDE) && 
+        (stage2_frequency_index == FREQUENCIES_PER_STAGE)) {
+      break;
+    }
+    if (stage2_fine_step == SYNC_STAGE_234_SUBDIVIDE) {
+      stage2_fine_step = 0;
+      stage2_frequency_index++;
+      ADC_InputTailAdvance(samples_per_symbol - (stage2_offsets[SYNC_STAGE_234_SUBDIVIDE - 1] - stage2_offsets[0]));
+    }
+    else {
+      ADC_InputTailAdvance(stage2_offsets[stage2_fine_step] - stage2_offsets[stage2_fine_step - 1]);
+    }
+  }
+}
+
+void waitSynchronizationComplete(uint16_t final_rollover_index, uint16_t final_buffer_index)
+{
+  while (ADC_TailRolloverCount(false) < final_rollover_index) {
+    ADC_InputSetTail(ADC_InputGetHead());
+    osDelay(1);
+  }
+  ADC_InputSetTail(ADC_InputGetHead());
+  while (ADC_InputGetHead() < final_buffer_index && (ADC_TailRolloverCount(false) == final_rollover_index)) {
+    ADC_InputSetTail(ADC_InputGetHead());
+    osDelay(1);
+  }
+  ADC_InputSetTail(final_buffer_index);
+}
+
+void populateGoertzelInfo(GoertzelInfo_t* goertzel_info)
+{
+  goertzel_info->buf_len = PROCESSING_BUFFER_SIZE;
+  goertzel_info->data_len = samples_per_symbol;
+  goertzel_info->window = window;
+  goertzel_info->energy_normalization = Demodulate_PowerNormalization();
+  goertzel_info->window_size = 512;
+}
+
+bool evaluateStage2Results()
+{
+  uint16_t best_index = 0;
+  float best_snr = 0.0f;
+
+  if (stage2_fine_step != SYNC_STAGE_234_SUBDIVIDE && stage2_frequency_index != FREQUENCIES_PER_STAGE) {
+    return false;
+  }
+
+  for (uint8_t i = 0; i < SYNC_STAGE_234_SUBDIVIDE; i++) {
+    float uncapped_snr = stage2_results[i].uncapped_snr_score;
+    float capped_snr = stage2_results[i].snr_score;
+    uint8_t num_exceeding = stage2_results[i].symbols_exceeding_threshold;
+    if ((uncapped_snr > best_snr) && (num_exceeding >= MIN_SYMBOLS_EXCEEDING_SNR) && (capped_snr >= TARGET_SNR)) {
+      best_snr = uncapped_snr;
+      best_index = i;
+    }
+  }
+
+  // failed synchronization at the second stage
+  if (best_snr < TARGET_SNR) {
+    Sync_Reset();
+    return false;
+  }
+
+  uint32_t samples_to_wait = 24 * samples_per_symbol;
+
+  uint64_t current_samples = stage2_results[best_index].rollover_count * PROCESSING_BUFFER_SIZE;
+  current_samples += stage2_results[best_index].buffer_index;
+
+  uint64_t target_samples = current_samples + samples_to_wait;
+  uint16_t final_rollover_count = target_samples / PROCESSING_BUFFER_SIZE;
+  uint16_t final_buffer_index = target_samples % PROCESSING_BUFFER_SIZE;
+
+  waitSynchronizationComplete(final_rollover_count, final_buffer_index);
+  return true;
 }

--- a/Application/Src/MESS/mess_sync.c
+++ b/Application/Src/MESS/mess_sync.c
@@ -10,29 +10,81 @@
 #include "mess_sync.h"
 #include "mess_packet.h"
 #include "mess_dsp_config.h"
+#include "mess_input.h"
+#include "mess_modulate.h"
+#include "mess_adc.h"
+#include "mess_demodulate.h"
+#include "mess_background_noise.h"
+#include "cfg_main.h"
 #include "dac_waveform.h"
+#include "goertzel.h"
 #include <string.h>
 #include <stdbool.h>
 
 /* Private typedef -----------------------------------------------------------*/
 
+typedef enum {
+  PN_STAGE_1,
+  PN_STAGE_2,
+  PN_STAGE_3,
+  PN_STAGE_4,
+  PN_STAGE_COMPLETE
+} JanusPnStage_t;
 
+#define FREQUENCIES_PER_STAGE   8
+typedef struct {
+  uint16_t rollover_index;
+  uint16_t buffer_index;
+  float energies[FREQUENCIES_PER_STAGE + 1]; // extra 1 to check the next frequency for bleeding
+  float snr_score;
+  float uncapped_snr_score;
+  uint8_t symbols_exceeding_threshold;
+} WindowedGoertzel_t;
 
 /* Private define ------------------------------------------------------------*/
 
+#define MIN_SYMBOLS_EXCEEDING_SNR 6
+#define SYNC_STAGE_1_STEP         30
+#define SYNC_STAGE_1_SUBDIVIDE    16
+#define SYNC_STAGE_234_SUBDIVIDE  16
+#define STAGE_RESULTS_LEN         512 // exxcessive for poc //((FREQUENCIES_PER_STAGE + 4) * SYNC_STAGE_1_SUBDIVIDE)
+#define COARSE_STEP_PRECISION     6
 
+#define TARGET_SNR                (8.0f)
 
 /* Private macro -------------------------------------------------------------*/
 
-
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
 /* Private variables ---------------------------------------------------------*/
 
+extern float window[512];
+
 static const uint32_t janus_pn_32 = 0b10101110110001111100110100100000U;
+static uint32_t janus_frequencies[32];
+static uint16_t window_offsets[SYNC_STAGE_1_SUBDIVIDE];
+static uint16_t samples_per_symbol;
+static JanusPnStage_t sync_stage = PN_STAGE_1;
+static WindowedGoertzel_t stage_results[STAGE_RESULTS_LEN];
+static uint16_t stage_results_head = 0;
+static uint16_t stage_results_len = 0;
+static uint16_t window_offset_index = 0;
+static uint16_t processed_buffer_tail = 0;
+static uint16_t processed_buffer_len = 0;
+
+static volatile bool sync_error = false;
 
 /* Private function prototypes -----------------------------------------------*/
 
+static void updateParameters(const DspConfig_t* cfg);
 static bool janusPnStep(bool* bit, uint16_t step);
+static void fillJanusFrequencies(const DspConfig_t* cfg);
+static void fillWindowOffsets(const DspConfig_t* cfg);
+static bool janusPnSynchronize(const DspConfig_t* cfg);
+static void populateResultsStage1(uint16_t start_index, uint16_t end_index, const DspConfig_t* cfg);
+static void scoreOffsets(const DspConfig_t* cfg);
+static bool findGlobalMax(const DspConfig_t* cfg);
+static void stage1TailIncrement();
 
 /* Exported function definitions ---------------------------------------------*/
 
@@ -64,14 +116,260 @@ uint16_t Sync_NumSteps(const DspConfig_t* cfg)
 
 bool Sync_Synchronize(const DspConfig_t* cfg)
 {
-  return true;
+  updateParameters(cfg);
+  switch (cfg->sync_method) {
+    case NO_SYNC:
+      return Input_DetectMessageStart(cfg);
+    case SYNC_PN_32_JANUS:
+      return janusPnSynchronize(cfg);
+    default:
+      return false;
+  }
+}
+
+void Sync_Reset()
+{
+  memset(stage_results, 0, sizeof(stage_results));
+  stage_results_head = 0;
+  stage_results_len = 0;
+  window_offset_index = 0;
+  processed_buffer_tail = 0;
+  processed_buffer_len = 0;
+  sync_stage = PN_STAGE_1;
 }
 
 /* Private function definitions ----------------------------------------------*/
+
+void updateParameters(const DspConfig_t* cfg)
+{
+  static uint32_t previous_version_number = 0; 
+  uint32_t current_version_number = CFG_GetVersionNumber(); 
+
+  if (current_version_number == previous_version_number) {
+    return; // No update needed
+  }
+  previous_version_number = current_version_number;
+  fillJanusFrequencies(cfg);
+  fillWindowOffsets(cfg);
+}
 
 bool janusPnStep(bool* bit, uint16_t step)
 {
   if (step >= 32) return false;
   *bit = (janus_pn_32 >> (31 - step)) & 1;
   return true;
+}
+
+// TODO: change for FSK and consider implications of penalty function
+void fillJanusFrequencies(const DspConfig_t* cfg)
+{
+  for (uint16_t i = 0; i < 32; i++) {
+    bool bit;
+    janusPnStep(&bit, i);
+    janus_frequencies[i] = Modulate_GetFhbfskFrequency(bit, i, cfg);
+  }
+}
+
+void fillWindowOffsets(const DspConfig_t* cfg)
+{
+  // Adding additional precision when calculating the offsets has an especially
+  // high significance when the baud rate is high and/or the samples per symbol
+  // is far from a multiple of stage 1 subdivide. Without the additional
+  // precision, there can be up to the subdivide/2 missing samples.
+  static const uint8_t offsets_precision = 4;
+  samples_per_symbol = (uint16_t) ((float) ADC_SAMPLING_RATE / cfg->baud_rate);
+  uint32_t offsets_increment = (samples_per_symbol << offsets_precision) / SYNC_STAGE_1_SUBDIVIDE;
+  for (uint8_t i = 0; i < SYNC_STAGE_1_SUBDIVIDE; i++) {
+    window_offsets[i] = (i * offsets_increment) >> offsets_precision;
+  }
+}
+
+bool janusPnSynchronize(const DspConfig_t* cfg)
+{
+  switch (sync_stage) {
+    case PN_STAGE_1:
+      populateResultsStage1(0, 8, cfg);
+      scoreOffsets(cfg);
+      return findGlobalMax(cfg);
+    case PN_STAGE_2:
+    case PN_STAGE_3:
+    case PN_STAGE_4:
+    case PN_STAGE_COMPLETE:
+      break;
+    default:
+      return false;
+  }
+  return false;
+}
+
+void populateResultsStage1(uint16_t start_index, uint16_t end_index, const DspConfig_t* cfg)
+{
+  GoertzelInfo_t goertzel_info;
+  goertzel_info.buf_len = PROCESSING_BUFFER_SIZE;
+  goertzel_info.data_len = samples_per_symbol;
+  goertzel_info.window = window;
+  goertzel_info.energy_normalization = Demodulate_PowerNormalization();
+  goertzel_info.window_size = 512;
+  uint32_t f[6];
+  goertzel_info.f = f;
+  float e_f[6];
+  goertzel_info.e_f = e_f;
+  while (ADC_InputAvailableSamples() > goertzel_info.data_len) {
+    goertzel_info.start_pos = ADC_InputGetTail();
+    uint16_t num_frequencies = end_index - start_index + 1;
+    while (num_frequencies >= 6) {
+      for (uint8_t i = 0; i < 6; i++) {
+        f[i] = janus_frequencies[end_index - num_frequencies + 1 + i];
+      }
+      goertzel_6(&goertzel_info);
+      for (uint8_t i = 0; i < 6; i++) {
+        stage_results[stage_results_head].energies[end_index - num_frequencies + 1 + i] = goertzel_info.e_f[i];
+      }
+      num_frequencies -= 6;
+    }
+
+    while (num_frequencies >= 2) {
+      for (uint8_t i = 0; i < 2; i++) {
+        f[i] = janus_frequencies[end_index - num_frequencies + 1 + i];
+      }
+      goertzel_2(&goertzel_info);
+      for (uint8_t i = 0; i < 2; i++) {
+        stage_results[stage_results_head].energies[end_index - num_frequencies + 1 + i] = goertzel_info.e_f[i];
+      }
+      num_frequencies -= 2;
+    }
+
+    while (num_frequencies >= 1) {
+      for (uint8_t i = 0; i < 1; i++) {
+        f[i] = janus_frequencies[end_index - num_frequencies + 1 + i];
+      }
+      goertzel_1(&goertzel_info);
+      for (uint8_t i = 0; i < 1; i++) {
+        stage_results[stage_results_head].energies[end_index - num_frequencies + 1 + i] = goertzel_info.e_f[i];
+      }
+      num_frequencies -= 1;
+    }
+    stage_results[stage_results_head].buffer_index = goertzel_info.start_pos;
+    stage_results[stage_results_head].rollover_index = ADC_TailRolloverCount(false);
+    stage_results_head = (stage_results_head + 1) % STAGE_RESULTS_LEN;
+    stage_results_len++;
+    if (stage_results_len >= STAGE_RESULTS_LEN) {
+      sync_error = true;
+      return;
+    }
+    stage1TailIncrement();
+  }
+}
+
+void scoreOffsets(const DspConfig_t* cfg)
+{
+  uint16_t results_per_stage = SYNC_STAGE_1_SUBDIVIDE * FREQUENCIES_PER_STAGE;
+
+  if (BackgroundNoise_Ready() == false) {
+    stage_results_len = 0;
+    return;
+  }
+
+  float background_noise = BackgroundNoise_Get();
+
+  while (stage_results_len > results_per_stage) {
+    uint16_t base_index = (stage_results_head - stage_results_len) & (STAGE_RESULTS_LEN - 1);
+    float snr = 0;
+    float uncapped_snr = 0;
+    stage_results[base_index].symbols_exceeding_threshold = 0;
+    
+    for (uint16_t i = 0; i < FREQUENCIES_PER_STAGE; i++) {
+      uint16_t freq_index = (base_index + i * SYNC_STAGE_1_SUBDIVIDE) & (STAGE_RESULTS_LEN - 1);
+      float frequency_energy = stage_results[freq_index].energies[i];
+      // penalty for including the next bin
+      frequency_energy -= stage_results[freq_index].energies[i + 1];
+      float snr_score = frequency_energy / background_noise;
+      snr += MIN(snr_score, TARGET_SNR * 2);
+      uncapped_snr += snr_score;
+      if (snr_score >= TARGET_SNR) {
+        stage_results[base_index].symbols_exceeding_threshold++;
+      }
+    }
+    
+    snr /= FREQUENCIES_PER_STAGE;
+    uncapped_snr /= FREQUENCIES_PER_STAGE;
+    stage_results[base_index].snr_score = snr;
+    stage_results[base_index].uncapped_snr_score = uncapped_snr;
+    stage_results_len--;
+    processed_buffer_len++;
+  }
+}
+
+bool findGlobalMax(const DspConfig_t* cfg)
+{
+  const uint16_t margin = 3;
+  uint16_t best_index = 0;
+  float best_snr = 0.0f;
+
+  if (processed_buffer_len < margin) {
+    return false;
+  }
+
+  for (uint16_t i = 0; i < processed_buffer_len; i++) {
+    uint16_t results_index = (i + processed_buffer_tail) % STAGE_RESULTS_LEN;
+    float uncapped_snr = stage_results[results_index].uncapped_snr_score;
+    float capped_snr = stage_results[results_index].snr_score;
+    uint8_t num_exceeding = stage_results[results_index].symbols_exceeding_threshold;
+    if ((uncapped_snr > best_snr) && (num_exceeding >= MIN_SYMBOLS_EXCEEDING_SNR) && (capped_snr >= TARGET_SNR)) {
+      best_snr = uncapped_snr;
+      best_index = results_index;
+    }
+  }
+
+  uint16_t results_searched = processed_buffer_len - margin;
+
+  if (best_snr < TARGET_SNR) {
+    processed_buffer_len -= results_searched;
+    processed_buffer_tail += results_searched;
+    processed_buffer_tail %= STAGE_RESULTS_LEN;
+    return false;
+  }
+  uint16_t distance_from_end = (processed_buffer_tail + processed_buffer_len - best_index) % STAGE_RESULTS_LEN;
+  // Found a max but it is too close to the end.
+  if (distance_from_end <= margin) {
+    processed_buffer_len -= results_searched;
+    processed_buffer_tail += results_searched;
+    processed_buffer_tail %= STAGE_RESULTS_LEN;
+    return false;
+  }
+
+  uint32_t samples_to_wait = 32 * samples_per_symbol;
+
+  uint64_t current_samples = PROCESSING_BUFFER_SIZE * stage_results[best_index].rollover_index;
+  current_samples += stage_results[best_index].buffer_index;
+
+  uint64_t target_total_samples = current_samples + samples_to_wait;
+
+  uint16_t target_rollover = target_total_samples / PROCESSING_BUFFER_SIZE;
+  uint16_t target_samples = target_total_samples % PROCESSING_BUFFER_SIZE;
+
+  while (ADC_TailRolloverCount(false) < target_rollover) {
+    ADC_InputSetTail(ADC_InputGetHead());
+    osDelay(1);
+  }
+  ADC_InputSetTail(ADC_InputGetHead());
+  while (ADC_InputGetHead() < target_samples && (ADC_TailRolloverCount(false) == target_rollover)) {
+    ADC_InputSetTail(ADC_InputGetHead());
+    osDelay(1);
+  }
+  ADC_InputSetTail(target_samples);
+  return true;
+}
+
+void stage1TailIncrement()
+{
+  uint16_t increment_amount;
+  if (window_offset_index == (SYNC_STAGE_1_SUBDIVIDE - 1)) {
+    increment_amount = samples_per_symbol - window_offsets[window_offset_index];
+  }
+  else {
+    increment_amount = window_offsets[window_offset_index + 1] - window_offsets[window_offset_index];
+  }
+  ADC_InputTailAdvance(increment_amount);
+  window_offset_index = (window_offset_index + 1) % SYNC_STAGE_1_SUBDIVIDE;
 }

--- a/Application/Src/common/utils/goertzel.c
+++ b/Application/Src/common/utils/goertzel.c
@@ -181,11 +181,11 @@ void goertzel_6(GoertzelInfo_t* goertzel_info)
   float normalization_factor = goertzel_info->energy_normalization / goertzel_info->data_len;
 
   energy_f0 = q1_f0 * q1_f0 + q2_f0 * q2_f0 - coeff_f0 * q1_f0 * q2_f0;
-  energy_f0 = q1_f1 * q1_f1 + q2_f1 * q2_f1 - coeff_f0 * q1_f1 * q2_f1;
-  energy_f0 = q1_f2 * q1_f2 + q2_f2 * q2_f2 - coeff_f0 * q1_f2 * q2_f2;
-  energy_f0 = q1_f3 * q1_f3 + q2_f3 * q2_f3 - coeff_f0 * q1_f3 * q2_f3;
-  energy_f0 = q1_f4 * q1_f4 + q2_f4 * q2_f4 - coeff_f0 * q1_f4 * q2_f4;
-  energy_f0 = q1_f5 * q1_f5 + q2_f5 * q2_f5 - coeff_f0 * q1_f5 * q2_f5;
+  energy_f1 = q1_f1 * q1_f1 + q2_f1 * q2_f1 - coeff_f0 * q1_f1 * q2_f1;
+  energy_f2 = q1_f2 * q1_f2 + q2_f2 * q2_f2 - coeff_f0 * q1_f2 * q2_f2;
+  energy_f3 = q1_f3 * q1_f3 + q2_f3 * q2_f3 - coeff_f0 * q1_f3 * q2_f3;
+  energy_f4 = q1_f4 * q1_f4 + q2_f4 * q2_f4 - coeff_f0 * q1_f4 * q2_f4;
+  energy_f5 = q1_f5 * q1_f5 + q2_f5 * q2_f5 - coeff_f0 * q1_f5 * q2_f5;
 
   goertzel_info->e_f[0] = energy_f0 * normalization_factor;
   goertzel_info->e_f[1] = energy_f1 * normalization_factor;

--- a/Application/Src/common/utils/goertzel.c
+++ b/Application/Src/common/utils/goertzel.c
@@ -60,12 +60,11 @@ void goertzel_1(GoertzelInfo_t* goertzel_info)
     window_index += window_increment;
   }
 
-  float normalization_factor = (float) goertzel_info->data_len;
-  normalization_factor *= normalization_factor;
+  float normalization_factor = goertzel_info->energy_normalization / goertzel_info->data_len;
 
   energy_f0 = q1_f0 * q1_f0 + q2_f0 * q2_f0 - coeff_f0 * q1_f0 * q2_f0;
 
-  goertzel_info->e_f[0] = energy_f0 / normalization_factor;
+  goertzel_info->e_f[0] = energy_f0 * normalization_factor;
 }
 
 void goertzel_2(GoertzelInfo_t* goertzel_info)
@@ -103,14 +102,13 @@ void goertzel_2(GoertzelInfo_t* goertzel_info)
     window_index += window_increment;
   }
 
-  float normalization_factor = (float) goertzel_info->data_len;
-  normalization_factor *= normalization_factor;
+  float normalization_factor = goertzel_info->energy_normalization / goertzel_info->data_len;
 
   energy_f0 = q1_f0 * q1_f0 + q2_f0 * q2_f0 - coeff_f0 * q1_f0 * q2_f0;
   energy_f1 = q1_f1 * q1_f1 + q2_f1 * q2_f1 - coeff_f1 * q1_f1 * q2_f1;
 
-  goertzel_info->e_f[0] = energy_f0 / normalization_factor;
-  goertzel_info->e_f[1] = energy_f1 / normalization_factor;
+  goertzel_info->e_f[0] = energy_f0 * normalization_factor;
+  goertzel_info->e_f[1] = energy_f1 * normalization_factor;
 }
 
 void goertzel_6(GoertzelInfo_t* goertzel_info)
@@ -180,8 +178,7 @@ void goertzel_6(GoertzelInfo_t* goertzel_info)
     window_index += window_increment;
   }
 
-  float normalization_factor = (float) goertzel_info->data_len;
-  normalization_factor *= normalization_factor;
+  float normalization_factor = goertzel_info->energy_normalization / goertzel_info->data_len;
 
   energy_f0 = q1_f0 * q1_f0 + q2_f0 * q2_f0 - coeff_f0 * q1_f0 * q2_f0;
   energy_f0 = q1_f1 * q1_f1 + q2_f1 * q2_f1 - coeff_f0 * q1_f1 * q2_f1;
@@ -190,12 +187,12 @@ void goertzel_6(GoertzelInfo_t* goertzel_info)
   energy_f0 = q1_f4 * q1_f4 + q2_f4 * q2_f4 - coeff_f0 * q1_f4 * q2_f4;
   energy_f0 = q1_f5 * q1_f5 + q2_f5 * q2_f5 - coeff_f0 * q1_f5 * q2_f5;
 
-  goertzel_info->e_f[0] = energy_f0 / normalization_factor;
-  goertzel_info->e_f[1] = energy_f1 / normalization_factor;
-  goertzel_info->e_f[2] = energy_f2 / normalization_factor;
-  goertzel_info->e_f[3] = energy_f3 / normalization_factor;
-  goertzel_info->e_f[4] = energy_f4 / normalization_factor;
-  goertzel_info->e_f[5] = energy_f5 / normalization_factor;
+  goertzel_info->e_f[0] = energy_f0 * normalization_factor;
+  goertzel_info->e_f[1] = energy_f1 * normalization_factor;
+  goertzel_info->e_f[2] = energy_f2 * normalization_factor;
+  goertzel_info->e_f[3] = energy_f3 * normalization_factor;
+  goertzel_info->e_f[4] = energy_f4 * normalization_factor;
+  goertzel_info->e_f[5] = energy_f5 * normalization_factor;
 }
 
 /* Private function definitions ----------------------------------------------*/

--- a/Application/Src/common/utils/goertzel.c
+++ b/Application/Src/common/utils/goertzel.c
@@ -1,0 +1,201 @@
+/*
+ * goertzel.c
+ *
+ *  Created on: Jul 13, 2025
+ *      Author: ericv
+ */
+
+/* Private includes ----------------------------------------------------------*/
+
+#include "goertzel.h"
+#include "uam_math.h"
+#include "mess_adc.h"
+
+/* Private typedef -----------------------------------------------------------*/
+
+
+
+/* Private define ------------------------------------------------------------*/
+
+#define WINDOW_PRECISION    8
+
+/* Private macro -------------------------------------------------------------*/
+
+
+
+/* Private variables ---------------------------------------------------------*/
+
+
+
+/* Private function prototypes -----------------------------------------------*/
+
+
+
+/* Exported function definitions ---------------------------------------------*/
+
+void goertzel_1(GoertzelInfo_t* goertzel_info)
+{
+  float energy_f0 = 0.0;
+
+  float omega_f0 = 2.0 * goertzel_info->f[0] / ADC_SAMPLING_RATE;
+
+  float coeff_f0 = 2.0 * uam_cosf(omega_f0);
+
+  uint16_t mask = goertzel_info->buf_len - 1;
+
+  float q0_f0 = 0, q1_f0 = 0, q2_f0 = 0;
+
+  uint32_t window_index = 0;
+  uint32_t window_increment = (goertzel_info->window_size << WINDOW_PRECISION)
+                              / goertzel_info->data_len;
+
+  for (uint16_t i = 0; i < goertzel_info->data_len; i++) {
+    float window_value = goertzel_info->window[(window_index >> WINDOW_PRECISION)];
+    uint16_t index = (i + goertzel_info->start_pos) & mask;
+    float data_value = ADC_InputGetDataAbsolute(index) * window_value;
+
+    q0_f0 = coeff_f0 * q1_f0 - q2_f0 + data_value;
+    q2_f0 = q1_f0;
+    q1_f0 = q0_f0;
+    window_index += window_increment;
+  }
+
+  float normalization_factor = (float) goertzel_info->data_len;
+  normalization_factor *= normalization_factor;
+
+  energy_f0 = q1_f0 * q1_f0 + q2_f0 * q2_f0 - coeff_f0 * q1_f0 * q2_f0;
+
+  goertzel_info->e_f[0] = energy_f0 / normalization_factor;
+}
+
+void goertzel_2(GoertzelInfo_t* goertzel_info)
+{
+  float energy_f0 = 0.0;
+  float energy_f1 = 0.0;
+
+  float omega_f0 = 2.0 * goertzel_info->f[0] / ADC_SAMPLING_RATE;
+  float omega_f1 = 2.0 * goertzel_info->f[1] / ADC_SAMPLING_RATE;
+
+  float coeff_f0 = 2.0 * uam_cosf(omega_f0);
+  float coeff_f1 = 2.0 * uam_cosf(omega_f1);
+
+  uint16_t mask = goertzel_info->buf_len - 1;
+
+  float q0_f0 = 0, q1_f0 = 0, q2_f0 = 0;
+  float q0_f1 = 0, q1_f1 = 0, q2_f1 = 0;
+
+  uint32_t window_index = 0;
+  uint32_t window_increment = (goertzel_info->window_size << WINDOW_PRECISION)
+                              / goertzel_info->data_len;
+
+  for (uint16_t i = 0; i < goertzel_info->data_len; i++) {
+    float window_value = goertzel_info->window[(window_index >> WINDOW_PRECISION)];
+    uint16_t index = (i + goertzel_info->start_pos) & mask;
+    float data_value = ADC_InputGetDataAbsolute(index) * window_value;
+
+    q0_f0 = coeff_f0 * q1_f0 - q2_f0 + data_value;
+    q2_f0 = q1_f0;
+    q1_f0 = q0_f0;
+
+    q0_f1 = coeff_f1 * q1_f1 - q2_f1 + data_value;
+    q2_f1 = q1_f1;
+    q1_f1 = q0_f1;
+    window_index += window_increment;
+  }
+
+  float normalization_factor = (float) goertzel_info->data_len;
+  normalization_factor *= normalization_factor;
+
+  energy_f0 = q1_f0 * q1_f0 + q2_f0 * q2_f0 - coeff_f0 * q1_f0 * q2_f0;
+  energy_f1 = q1_f1 * q1_f1 + q2_f1 * q2_f1 - coeff_f1 * q1_f1 * q2_f1;
+
+  goertzel_info->e_f[0] = energy_f0 / normalization_factor;
+  goertzel_info->e_f[1] = energy_f1 / normalization_factor;
+}
+
+void goertzel_6(GoertzelInfo_t* goertzel_info)
+{
+  float energy_f0 = 0.0;
+  float energy_f1 = 0.0;
+  float energy_f2 = 0.0;
+  float energy_f3 = 0.0;
+  float energy_f4 = 0.0;
+  float energy_f5 = 0.0;
+
+  float omega_f0 = 2.0 * goertzel_info->f[0] / ADC_SAMPLING_RATE;
+  float omega_f1 = 2.0 * goertzel_info->f[1] / ADC_SAMPLING_RATE;
+  float omega_f2 = 2.0 * goertzel_info->f[2] / ADC_SAMPLING_RATE;
+  float omega_f3 = 2.0 * goertzel_info->f[3] / ADC_SAMPLING_RATE;
+  float omega_f4 = 2.0 * goertzel_info->f[4] / ADC_SAMPLING_RATE;
+  float omega_f5 = 2.0 * goertzel_info->f[5] / ADC_SAMPLING_RATE;
+
+  float coeff_f0 = 2.0 * uam_cosf(omega_f0);
+  float coeff_f1 = 2.0 * uam_cosf(omega_f1);
+  float coeff_f2 = 2.0 * uam_cosf(omega_f2);
+  float coeff_f3 = 2.0 * uam_cosf(omega_f3);
+  float coeff_f4 = 2.0 * uam_cosf(omega_f4);
+  float coeff_f5 = 2.0 * uam_cosf(omega_f5);
+
+  uint16_t mask = goertzel_info->buf_len - 1;
+
+  float q0_f0 = 0, q1_f0 = 0, q2_f0 = 0;
+  float q0_f1 = 0, q1_f1 = 0, q2_f1 = 0;
+  float q0_f2 = 0, q1_f2 = 0, q2_f2 = 0;
+  float q0_f3 = 0, q1_f3 = 0, q2_f3 = 0;
+  float q0_f4 = 0, q1_f4 = 0, q2_f4 = 0;
+  float q0_f5 = 0, q1_f5 = 0, q2_f5 = 0;
+
+  uint32_t window_index = 0;
+  uint32_t window_increment = (goertzel_info->window_size << WINDOW_PRECISION)
+                              / goertzel_info->data_len;
+
+  for (uint16_t i = 0; i < goertzel_info->data_len; i++) {
+    float window_value = goertzel_info->window[(window_index >> WINDOW_PRECISION)];
+    uint16_t index = (i + goertzel_info->start_pos) & mask;
+    float data_value = ADC_InputGetDataAbsolute(index) * window_value;
+
+    q0_f0 = coeff_f0 * q1_f0 - q2_f0 + data_value;
+    q2_f0 = q1_f0;
+    q1_f0 = q0_f0;
+
+    q0_f1 = coeff_f1 * q1_f1 - q2_f1 + data_value;
+    q2_f1 = q1_f1;
+    q1_f1 = q0_f1;
+
+    q0_f2 = coeff_f2 * q1_f2 - q2_f2 + data_value;
+    q2_f2 = q1_f2;
+    q1_f2 = q0_f2;
+
+    q0_f3 = coeff_f3 * q1_f3 - q2_f3 + data_value;
+    q2_f3 = q1_f3;
+    q1_f3 = q0_f3;
+
+    q0_f4 = coeff_f4 * q1_f4 - q2_f4 + data_value;
+    q2_f4 = q1_f4;
+    q1_f4 = q0_f4;
+
+    q0_f5 = coeff_f5 * q1_f5 - q2_f5 + data_value;
+    q2_f5 = q1_f5;
+    q1_f5 = q0_f5;
+    window_index += window_increment;
+  }
+
+  float normalization_factor = (float) goertzel_info->data_len;
+  normalization_factor *= normalization_factor;
+
+  energy_f0 = q1_f0 * q1_f0 + q2_f0 * q2_f0 - coeff_f0 * q1_f0 * q2_f0;
+  energy_f0 = q1_f1 * q1_f1 + q2_f1 * q2_f1 - coeff_f0 * q1_f1 * q2_f1;
+  energy_f0 = q1_f2 * q1_f2 + q2_f2 * q2_f2 - coeff_f0 * q1_f2 * q2_f2;
+  energy_f0 = q1_f3 * q1_f3 + q2_f3 * q2_f3 - coeff_f0 * q1_f3 * q2_f3;
+  energy_f0 = q1_f4 * q1_f4 + q2_f4 * q2_f4 - coeff_f0 * q1_f4 * q2_f4;
+  energy_f0 = q1_f5 * q1_f5 + q2_f5 * q2_f5 - coeff_f0 * q1_f5 * q2_f5;
+
+  goertzel_info->e_f[0] = energy_f0 / normalization_factor;
+  goertzel_info->e_f[1] = energy_f1 / normalization_factor;
+  goertzel_info->e_f[2] = energy_f2 / normalization_factor;
+  goertzel_info->e_f[3] = energy_f3 / normalization_factor;
+  goertzel_info->e_f[4] = energy_f4 / normalization_factor;
+  goertzel_info->e_f[5] = energy_f5 / normalization_factor;
+}
+
+/* Private function definitions ----------------------------------------------*/


### PR DESCRIPTION
Using the JANUS PN sequence, a synchronizer was made. So far only 16 bits of the message are used but this is enough for consistent 9 dB SNR message detection. A lower SNR could also be possible with this method but there could be more false triggers of stage 1 leading to potentially missed synchronization opportunities. CPU usage ~40%. Also added background noise estimator. The number of goertzel iterations per symbol is relatively low at 144 so the maximum number of goertzel iterations per symbol is ~300, considerably lower than the estimated 500-1000.