### PR TITLE
Sync sensitivity

### DIFF
--- a/Application/Src/MESS/mess_interleaver.c
+++ b/Application/Src/MESS/mess_interleaver.c
@@ -83,6 +83,7 @@ void Interleaver_Undo(BitMessage_t* bit_msg, const DspConfig_t* cfg, bool is_pre
 void interleave(uint16_t start_index, uint16_t length,
     BitMessage_t* input_bit_msg, BitMessage_t* buffer_bit_msg)
 {
+  if (length == 0) return;
   // If the length and the interleaver depth have a common denominator other
   // than 1, the interleaver will result in duplicate entries and lost data
   uint16_t interleaver_depth = findInterleavingDepth(length);
@@ -107,6 +108,7 @@ void interleave(uint16_t start_index, uint16_t length,
 void deinterleave(uint16_t start_index, uint16_t length,
     BitMessage_t* input_bit_msg, BitMessage_t* buffer_bit_msg)
 {
+  if (length == 0) return;
   // If the length and the interleaver depth have a common denominator other
   // than 1, the interleaver will result in duplicate entries and lost data
   uint16_t interleaver_depth = findInterleavingDepth(length);
@@ -150,7 +152,7 @@ uint16_t findInterleavingDepth(uint16_t length)
   }
 
   // No message should ever get here, but if it somehow does, remove condition 1
-  for (uint16_t i = num_primes - 1; i > 0; i++) {
+  for (uint16_t i = num_primes - 1; i > 0; i--) {
     uint16_t candidate_prime = primes[i];
     if (length % candidate_prime != 0) {
       return candidate_prime;

--- a/Application/Src/MESS/mess_ranging.c
+++ b/Application/Src/MESS/mess_ranging.c
@@ -29,7 +29,7 @@
 /* Private define ------------------------------------------------------------*/
 
 #define RANGING_TIMEOUT_MS            20000
-#define RANGING_RESPONSE_DELAY        2000
+#define RANGING_RESPONSE_DELAY        6000
 #define AFE_TURNAROUND_TIME           500
 
 // A fixed offset is required for ranging calibration. Uncertain on reason why TODO

--- a/Application/Src/MESS/mess_sync.c
+++ b/Application/Src/MESS/mess_sync.c
@@ -420,7 +420,7 @@ static void updateSlidingGoertzel(uint16_t new_samples)
     float signal_e = (k >= 0) ? sliding_goertzel_bank[k].e_f : 0.0f;
     float noise_e;
     if (k_noise >= 0) {
-      noise_e = MAX(sliding_goertzel_bank[k_noise].e_f, background_noise);
+      noise_e = MAX(sliding_goertzel_bank[k_noise].e_f * 0.5f, background_noise);
     } else {
       noise_e = background_noise;
     }


### PR DESCRIPTION
Fixes to address sync not always firing in high multipath by reducing multipath penalty and increased ranging delay enabling it to be used with lower baud rates